### PR TITLE
Prepare for auto-publishing to `@pulsar-edit/keyboard-layout` on NPM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           node-version: ${{ matrix.node_version }}
 
       - name: Install dependencies (Linux)
-        run: apt install libx11-dev
+        run: sudo apt install libx11-dev
         if: "contains(matrix.os, 'ubuntu')"
 
       - name: Install Python setuptools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
 
+      - name: Install dependencies (Linux)
+        run: apt install libx11-dev
+        if: "contains(matrix.os, 'ubuntu')"
+
       - name: Install Python setuptools
         # This is needed for Python 3.12+, since many versions of node-gyp
         # are incompatible with Python 3.12+, which no-longer ships 'distutils'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           node-version: ${{ matrix.node_version }}
 
       - name: Install dependencies (Linux)
-        run: sudo apt install libx11-dev libxcomposite-dev 
+        run: sudo apt install libx11-dev libxkbfile-dev
         if: "contains(matrix.os, 'ubuntu')"
 
       - name: Install Python setuptools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           node-version: ${{ matrix.node_version }}
 
       - name: Install dependencies (Linux)
-        run: sudo apt install libx11-dev
+        run: sudo apt install libx11-dev libxcomposite-dev 
         if: "contains(matrix.os, 'ubuntu')"
 
       - name: Install Python setuptools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
       - name: Install windows-build-tools
         if: ${{ matrix.os == 'windows-latest' }}
         run: npm config set msvs_version 2019

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,26 +1,47 @@
 name: CI
 
-on: [push]
-
-env:
-  CI: true
+on:
+  push:
+  pull_request:
 
 jobs:
   Test:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+    name: "Test"
     runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        node_version:
+          - 16
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+
+      - name: Install Node ${{ matrix.node }}
+        uses: actions/setup-node@v4
         with:
-          node-version: '16'
-      - name: Install windows-build-tools
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: npm config set msvs_version 2019
+          node-version: ${{ matrix.node_version }}
+
+      - name: Install Python setuptools
+        # This is needed for Python 3.12+, since many versions of node-gyp
+        # are incompatible with Python 3.12+, which no-longer ships 'distutils'
+        # out of the box. 'setuptools' package provides 'distutils'.
+        run: python3 -m pip install setuptools
+        if: "!contains(matrix.os, 'macos')"
+
+      - name: Install Python setuptools (macOS)
+        # This is needed for Python 3.12+, since many versions of node-gyp
+        # are incompatible with Python 3.12+, which no-longer ships 'distutils'
+        # out of the box. 'setuptools' package provides 'distutils'.
+        run: brew install python-setuptools
+        if: "contains(matrix.os, 'macos')"
+
       - name: Install dependencies
-        run: npm i
+        run: npm install
+
       - name: Run tests
         uses: GabrielBB/xvfb-action@v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: NPM Publish
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+env:
+  NODE_VERSION: 16
+  NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - run: npm ci
+      - run: npm test
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,8 @@ jobs:
         uses: GabrielBB/xvfb-action@v1
         with:
           node-version: ${{ env.NODE_VERSION }}
+      - run: sudo apt install libx11-dev libxkbfile-dev
+      - run: python3 -m pip install setuptools
       - run: npm ci
       - run: npm test
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ npm-debug.log
 *.swp
 build
 .vscode
+.cache
+.tool-versions
+compile_commands.json

--- a/binding.gyp
+++ b/binding.gyp
@@ -26,7 +26,7 @@
           ],
           'msvs_settings': {
             'VCCLCompilerTool': {
-              'ExceptionHandling': 1, # /EHsc
+              'ExceptionHandling': 1,  # /EHsc
               'WarnAsError': 'true',
             },
           },
@@ -37,7 +37,8 @@
             4267,  # conversion from 'size_t' to 'type', possible loss of data
             4302,  # 'type cast': truncation from 'HKL' to 'UINT'
             4311,  # 'type cast': pointer truncation from 'HKL' to 'UINT'
-            4530,  # C++ exception handler used, but unwind semantics are not enabled
+            4530,  # C++ exception handler used, but unwind semantics are not
+                   # enabled
             4506,  # no definition for inline function
             4577,  # 'noexcept' used with no exception handling mode specified
             4996,  # function was declared deprecated

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "keyboard-layout",
+  "name": "@pulsar-edit/keyboard-layout",
   "version": "2.0.17",
   "description": "Read and observe the current keyboard layout on OS X.",
   "main": "./lib/keyboard-layout",
@@ -8,15 +8,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/atom/keyboard-layout.git"
+    "url": "https://github.com/pulsar-edit/keyboard-layout.git"
   },
   "bugs": {
-    "url": "https://github.com/atom/keyboard-layout/issues"
+    "url": "https://github.com/pulsar-edit/keyboard-layout/issues"
   },
   "licenses": [
     {
       "type": "MIT",
-      "url": "http://github.com/atom/keyboard-layout/raw/master/LICENSE.md"
+      "url": "http://github.com/pulsar-edit/keyboard-layout/raw/master/LICENSE.md"
     }
   ],
   "dependencies": {


### PR DESCRIPTION
As with [the one for `git-utils`](https://github.com/pulsar-edit/git-utils/pull/2), this sets up auto-publishing to NPM upon release creation for `keyboard-layout`.

The steps are slightly different than in the last one, but this should theoretically work and defer compilation until `npm install` or `yarn install`.