### PR TITLE
Rewrite in N-API; add Wayland support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,13 @@ jobs:
         run: python3 -m pip install setuptools
         if: ${{ matrix.os != "macos-latest" }}
 
+      - name: Install Python setuptools (macOS)
+        # This is needed for Python 3.12+, since many versions of node-gyp
+        # are incompatible with Python 3.12+, which no-longer ships 'distutils'
+        # out of the box. 'setuptools' package provides 'distutils'.
+        run: brew install python-setuptools
+        if: ${{ matrix.os == "macos-latest" }}
+
       - name: Install dependencies
         run: npm install
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,26 +1,33 @@
 name: CI
 
-on: [push]
-
-env:
-  CI: true
+on:
+  push:
+  pull_request:
 
 jobs:
   Test:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+    name: "Test"
     runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        node_version:
+          - 20
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+
+      - name: Install Node ${{ matrix.node }}
+        uses: actions/setup-node@v4
         with:
-          node-version: '14'
-      - name: Install windows-build-tools
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: npm config set msvs_version 2019
+          node-version: ${{ matrix.node_version }}
+
       - name: Install dependencies
-        run: npm i
+        run: npm install
+        
       - name: Run tests
         uses: GabrielBB/xvfb-action@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,12 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
 
+      - name: Install Python setuptools
+        # This is needed for Python 3.12+, since many versions of node-gyp
+        # are incompatible with Python 3.12+, which no-longer ships 'distutils'
+        # out of the box. 'setuptools' package provides 'distutils'.
+        run: python3 -m pip install setuptools
+
       - name: Install dependencies
         run: npm install
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,14 +31,14 @@ jobs:
         # are incompatible with Python 3.12+, which no-longer ships 'distutils'
         # out of the box. 'setuptools' package provides 'distutils'.
         run: python3 -m pip install setuptools
-        if: ${{ matrix.os != "macos-latest" }}
+        if: "!contains(matrix.os, 'macos')"
 
       - name: Install Python setuptools (macOS)
         # This is needed for Python 3.12+, since many versions of node-gyp
         # are incompatible with Python 3.12+, which no-longer ships 'distutils'
         # out of the box. 'setuptools' package provides 'distutils'.
         run: brew install python-setuptools
-        if: ${{ matrix.os == "macos-latest" }}
+        if: "contains(matrix.os, 'macos')"
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         # are incompatible with Python 3.12+, which no-longer ships 'distutils'
         # out of the box. 'setuptools' package provides 'distutils'.
         run: python3 -m pip install setuptools
+        if: ${{ matrix.os != "macos-latest" }}
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
           - macos-latest
           - windows-latest
         node_version:
+          - 16
           - 20
     steps:
       - uses: actions/checkout@v4
@@ -27,7 +28,7 @@ jobs:
 
       - name: Install dependencies
         run: npm install
-        
+
       - name: Run tests
         uses: GabrielBB/xvfb-action@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install dependencies
         if: ${{ runner.os == 'Linux' }}
-        run: sudo apt-get update && sudo apt-get install libx11-dev libxkbfile-dev libwayland-dev libxkbcommon-dev
+        run: sudo apt-get update && sudo apt-get install libx11-dev libxkbfile-dev libwayland-dev libxkbcommon-dev libxkbcommon-x11-dev libxkbcommon0 xkb-data
 
       - name: Set up locale
         if: ${{ runner.os == 'Linux' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install dependencies
         if: ${{ runner.os == 'Linux' }}
-        run: sudo apt-get update && sudo apt-get install libx11-dev libxkbfile-dev libwayland-dev libwayland-client0 libxkbcommon-dev libxkbcommon-x11-dev libxkbcommon0 xkb-data
+        run: sudo apt-get update && sudo apt-get install libx11-dev libxkbfile-dev libwayland-dev wayland-protocols libwayland-client0 libwayland-cursor0 libwayland-egl1 libwayland-server0 weston weston-protocols-extra libweston-12-dev xvfb libxkbcommon-dev libxkbcommon-x11-dev libxkbcommon0 xkb-data input-utils
 
       - name: Set up locale
         if: ${{ runner.os == 'Linux' }}
@@ -60,6 +60,37 @@ jobs:
           echo "WAYLAND_DISPLAY? $WAYLAND_DISPLAY"
           echo "DISPLAY?: $DISPLAY"
 
+      - name: Set up virtual framebuffer and Wayland
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          # Start Xvfb
+          Xvfb :99 -screen 0 1024x768x24 &
+          export DISPLAY=:99
+
+          # Create temporary directory for Wayland socket
+          export XDG_RUNTIME_DIR=/tmp/wayland-test
+          mkdir -p $XDG_RUNTIME_DIR
+          chmod 700 $XDG_RUNTIME_DIR
+
+          # Create Weston config with AZERTY keyboard
+          mkdir -p $HOME/.config/weston
+          cat > $HOME/.config/weston/weston.ini << EOF
+          [keyboard]
+          keymap_layout=fr
+          keymap_variant=azerty
+          keymap_options=grp:alt_shift_toggle
+
+          [core]
+          xwayland=true
+          EOF
+
+          # Start Weston with the config
+          weston --backend=headless-backend.so --socket=wayland-test --width=1024 --height=768 &
+          export WAYLAND_DISPLAY=wayland-test
+
+          # Wait for Weston to be ready
+          sleep 5
+
       - name: Install Node ${{ matrix.node }}
         uses: actions/setup-node@v4
         with:
@@ -84,5 +115,18 @@ jobs:
 
       - name: Run tests
         uses: GabrielBB/xvfb-action@v1
+        if: ${{ runner.os != 'Linux' }}
         with:
           run: npm test
+
+      - name: Run tests (linux)
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          export XDG_RUNTIME_DIR=/tmp/wayland-test
+          export WAYLAND_DISPLAY=wayland-test
+          export DISPLAY=:99
+
+          export XKB_DEFAULT_LAYOUT=fr
+          export XKB_DEFAULT_VARIANT=azerty
+
+          npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install dependencies
         if: ${{ runner.os == 'Linux' }}
-        run: sudo apt-get update && sudo apt-get install libx11-dev libxkbfile-dev wayland-devel
+        run: sudo apt-get update && sudo apt-get install libx11-dev libxkbfile-dev libwayland-dev libxkbcommon-dev
 
       - name: Install Node ${{ matrix.node }}
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install dependencies
         if: ${{ runner.os == 'Linux' }}
-        run: apt-get update && apt-get install libx11-dev libxkbfile-dev
+        run: sudo apt-get update && sudo apt-get install libx11-dev libxkbfile-dev
 
       - name: Install Node ${{ matrix.node }}
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install dependencies
         if: ${{ runner.os == 'Linux' }}
-        run: sudo apt-get update && sudo apt-get install libx11-dev libxkbfile-dev libwayland-dev wayland-protocols libwayland-client0 libwayland-cursor0 libwayland-egl1 libwayland-server0 weston libweston-13-dev xvfb libxkbcommon-dev libxkbcommon-x11-dev libxkbcommon0 xkb-data input-utils
+        run: sudo apt-get update && sudo apt-get install libx11-dev libxkbfile-dev libwayland-dev libxkbcommon-dev libxkbcommon-x11-dev libxkbcommon0 xkb-data
 
       - name: Set up locale
         if: ${{ runner.os == 'Linux' }}
@@ -60,37 +60,6 @@ jobs:
           echo "WAYLAND_DISPLAY? $WAYLAND_DISPLAY"
           echo "DISPLAY?: $DISPLAY"
 
-      - name: Set up virtual framebuffer and Wayland
-        if: ${{ runner.os == 'Linux' }}
-        run: |
-          # Start Xvfb
-          Xvfb :99 -screen 0 1024x768x24 &
-          export DISPLAY=:99
-
-          # Create temporary directory for Wayland socket
-          export XDG_RUNTIME_DIR=/tmp/wayland-test
-          mkdir -p $XDG_RUNTIME_DIR
-          chmod 700 $XDG_RUNTIME_DIR
-
-          # Create Weston config with AZERTY keyboard
-          mkdir -p $HOME/.config/weston
-          cat > $HOME/.config/weston/weston.ini << EOF
-          [keyboard]
-          keymap_layout=fr
-          keymap_variant=azerty
-          keymap_options=grp:alt_shift_toggle
-
-          [core]
-          xwayland=true
-          EOF
-
-          # Start Weston with the config
-          weston --backend=headless-backend.so --socket=wayland-test --width=1024 --height=768 &
-          export WAYLAND_DISPLAY=wayland-test
-
-          # Wait for Weston to be ready
-          sleep 5
-
       - name: Install Node ${{ matrix.node }}
         uses: actions/setup-node@v4
         with:
@@ -115,18 +84,5 @@ jobs:
 
       - name: Run tests
         uses: GabrielBB/xvfb-action@v1
-        if: ${{ runner.os != 'Linux' }}
         with:
           run: npm test
-
-      - name: Run tests (linux)
-        if: ${{ runner.os == 'Linux' }}
-        run: |
-          export XDG_RUNTIME_DIR=/tmp/wayland-test
-          export WAYLAND_DISPLAY=wayland-test
-          export DISPLAY=:99
-
-          export XKB_DEFAULT_LAYOUT=fr
-          export XKB_DEFAULT_VARIANT=azerty
-
-          npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,14 @@ jobs:
           echo "Current locale:"
           locale
           echo "Current keyboard layout:"
-          cat /etc/default/keyboard | grep XKBLAYOUT          
+          cat /etc/default/keyboard | grep XKBLAYOUT
+
+      - name: Report session type
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          echo "X or Wayland? $XKB_SESSION_TYPE"
+          echo "WAYLAND_DISPLAY? $WAYLAND_DISPLAY"
+          echo "DISPLAY?: $DISPLAY"
 
       - name: Install Node ${{ matrix.node }}
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install dependencies
         if: ${{ runner.os == 'Linux' }}
-        run: sudo apt-get update && sudo apt-get install libx11-dev libxkbfile-dev
+        run: sudo apt-get update && sudo apt-get install libx11-dev libxkbfile-dev wayland-devel
 
       - name: Install Node ${{ matrix.node }}
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install dependencies
         if: ${{ runner.os == 'Linux' }}
-        run: sudo apt-get update && sudo apt-get install libx11-dev libxkbfile-dev libwayland-dev libxkbcommon-dev libxkbcommon-x11-dev libxkbcommon0 xkb-data
+        run: sudo apt-get update && sudo apt-get install libx11-dev libxkbfile-dev libwayland-dev libwayland-client0 libxkbcommon-dev libxkbcommon-x11-dev libxkbcommon0 xkb-data
 
       - name: Set up locale
         if: ${{ runner.os == 'Linux' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install dependencies
         if: ${{ runner.os == 'Linux' }}
-        run: sudo apt-get update && sudo apt-get install libx11-dev libxkbfile-dev libwayland-dev wayland-protocols libwayland-client0 libwayland-cursor0 libwayland-egl1 libwayland-server0 weston weston-protocols-extra libweston-12-dev xvfb libxkbcommon-dev libxkbcommon-x11-dev libxkbcommon0 xkb-data input-utils
+        run: sudo apt-get update && sudo apt-get install libx11-dev libxkbfile-dev libwayland-dev wayland-protocols libwayland-client0 libwayland-cursor0 libwayland-egl1 libwayland-server0 weston libweston-13-dev xvfb libxkbcommon-dev libxkbcommon-x11-dev libxkbcommon0 xkb-data input-utils
 
       - name: Set up locale
         if: ${{ runner.os == 'Linux' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,34 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         run: sudo apt-get update && sudo apt-get install libx11-dev libxkbfile-dev libwayland-dev libxkbcommon-dev
 
+      - name: Set up locale
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y locales
+          sudo locale-gen fr_FR.UTF-8  # Example: French locale
+          sudo update-locale LANG=fr_FR.UTF-8 LC_ALL=fr_FR.UTF-8
+          echo "LANG=fr_FR.UTF-8" | sudo tee -a /etc/environment
+          echo "LC_ALL=fr_FR.UTF-8" | sudo tee -a /etc/environment
+          # Apply and verify the change
+          source /etc/environment
+          locale
+
+      - name: Set keyboard layout
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y console-setup keyboard-configuration
+          # Set keyboard layout non-interactively
+          sudo sed -i 's/XKBLAYOUT=.*/XKBLAYOUT="fr"/' /etc/default/keyboard
+          sudo dpkg-reconfigure -f noninteractive keyboard-configuration
+          # Apply the changes
+          sudo setupcon
+          echo "Current locale:"
+          locale
+          echo "Current keyboard layout:"
+          cat /etc/default/keyboard | grep XKBLAYOUT          
+
       - name: Install Node ${{ matrix.node }}
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install dependencies
+        if: ${{ runner.os == 'Linux' }}
+        run: apt-get update && apt-get install libx11-dev libxkbfile-dev
+
       - name: Install Node ${{ matrix.node }}
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
       - run: npm test
 
   publish:
-    needs: build
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,9 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        uses: GabrielBB/xvfb-action@v1
         with:
           node-version: ${{ env.NODE_VERSION }}
+      - uses: GabrielBB/xvfb-action@v1
       - run: sudo apt install libx11-dev libxkbfile-dev
       - run: python3 -m pip install setuptools
       - run: npm ci

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 *.swp
 build
 .vscode
+.cache

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 build
 .vscode
 .cache
+compile_commands.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+.atom
 .DS_Store
 npm-debug.log
 *.swp

--- a/README.md
+++ b/README.md
@@ -42,3 +42,25 @@ On a US layout, this returns:
 }
 */
 ```
+
+
+## Caveats
+
+### Linux
+
+On Linux, there is minimal X11 support and somewhat more comprehensive Wayland support.
+
+#### Both Wayland and X11
+
+* There is no distinction between `getCurrentKeyboardLayout` and `getCurrentKeyboardLanguage`; the latter is an alias of the former.
+
+#### X11
+
+* `observeCurrentKeyboardLayout` is a no-op; we do not receive notifications when the keyboard layout changes. If you want to detect if the keyboard layout has changed, you must poll periodically.
+* `getCurrentKeymap` will return objects with only two properties: `unmodified` and `withShift`. Information is not available about which characters would be produced if `AltGr` or `AltGr+Shift` were pressed.
+
+#### Wayland
+
+* When Wayland support is enabled (as it will be if `libwayland-client` and `libxkbcommon` are present), this library will assume a Wayland environment is present, then fall back to X11 if Wayland setup fails in any way.
+* In a Wayland environment, `observeCurrentKeyboardLayout` works. However…
+* …the Wayland server (as implemented by your window manager) is the authority on when keyboard layouts change, and this might not align with your expectations. For instance, GNOME will change the active layout if you have several layouts and reorder them in your settings; it _will not_ change the active layout if you use keyboard shortcuts to switch “input sources” on the fly. Other window mangers may behave differently.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,15 @@
 # keyboard-layout
-[![CI](https://github.com/atom/keyboard-layout/actions/workflows/ci.yml/badge.svg)](https://github.com/atom/keyboard-layout/actions/workflows/ci.yml)
 
 Read and observe the current keyboard layout.
 
-To get the current keyboard layout, call `getCurrentKeyboardLayout`. It returns
-the string identifier of the current layout based on the value returned by the
-operating system.
+To get the current keyboard layout, call `getCurrentKeyboardLayout`. It returns the string identifier of the current layout based on the value returned by the operating system.
 
 ```js
 const KeyboardLayout = require('keyboard-layout')
 KeyboardLayout.getCurrentKeyboardLayout() // => "com.apple.keylayout.Dvorak"
 ```
 
-If you want to watch for layout changes, use `onDidChangeCurrentKeyboardLayout`
-or `observeCurrentKeyboardLayout`. They work the same, except
-`observeCurrentKeyboardLayout` invokes the given callback immediately with the
-current layout value and then again next time it changes, whereas
-`onDidChangeCurrentKeyboardLayout` only invokes the callback on the next
-change.
+If you want to watch for layout changes, use `onDidChangeCurrentKeyboardLayout` or `observeCurrentKeyboardLayout`. They work the same, except `observeCurrentKeyboardLayout` invokes the given callback immediately with the current layout value and then again next time it changes, whereas `onDidChangeCurrentKeyboardLayout` only invokes the callback on the next change.
 
 ```js
 const KeyboardLayout = require('keyboard-layout')
@@ -25,9 +17,7 @@ subscription = KeyboardLayout.observeCurrentKeyboardLayout((layout) => console.l
 subscription.dispose() // to unsubscribe later
 ```
 
-To return characters for various modifier states based on a DOM 3
-`KeyboardEvent.code` value and the current system keyboard layout, use
-`getCurrentKeymap()`:
+To return characters for various modifier states based on a DOM 3 `KeyboardEvent.code` value and the current system keyboard layout, use `getCurrentKeymap()`:
 
 ```js
 const KeyboardLayout = require('keyboard-layout')
@@ -46,6 +36,10 @@ On a US layout, this returns:
 
 ## Caveats
 
+### All platforms
+
+* Having an active layout change listener (via `onDidChangeCurrentKeyboardLayout` or `observeCurrentKeyboardLayout`) will not prevent the process from exiting.
+
 ### Linux
 
 On Linux, there is minimal X11 support and somewhat more comprehensive Wayland support.
@@ -56,7 +50,7 @@ On Linux, there is minimal X11 support and somewhat more comprehensive Wayland s
 
 #### X11
 
-* `observeCurrentKeyboardLayout` is a no-op; we do not receive notifications when the keyboard layout changes. If you want to detect if the keyboard layout has changed, you must poll periodically.
+* `onDidChangeCurrentKeyboardLayout` and `observeCurrentKeyboardLayout` are no-ops; we do not receive notifications when the keyboard layout changes. If you want to detect if the keyboard layout has changed, you must poll periodically.
 * `getCurrentKeymap` will return objects with only two properties: `unmodified` and `withShift`. Information is not available about which characters would be produced if `AltGr` or `AltGr+Shift` were pressed.
 
 #### Wayland

--- a/binding.gyp
+++ b/binding.gyp
@@ -2,11 +2,21 @@
   "targets": [
     {
       "target_name": "keyboard-layout-manager",
+      "cflags!": ["-fno-exceptions"],
+      "cflags_cc!": ["-fno-exceptions"],
+      "xcode_settings": {
+        "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+        "CLANG_CXX_LIBRARY": "libc++",
+        "MACOSX_DEPLOYMENT_TARGET": "10.7",
+      },
+      "msvs_settings": {
+        "VCCLCompilerTool": {"ExceptionHandling": 1},
+      },
       "sources": [
         "src/keyboard-layout-manager.cc"
       ],
       "include_dirs": [
-        "<!(node -e \"require('nan')\")",
+        "<!(node -p \"require('node-addon-api').include_dir\")",
         "chrome_headers",
       ],
       "conditions": [
@@ -26,7 +36,7 @@
           ],
           'msvs_settings': {
             'VCCLCompilerTool': {
-              'ExceptionHandling': 1, # /EHsc
+              'ExceptionHandling': 1,  # /EHsc
               'WarnAsError': 'true',
             },
           },
@@ -37,7 +47,8 @@
             4267,  # conversion from 'size_t' to 'type', possible loss of data
             4302,  # 'type cast': truncation from 'HKL' to 'UINT'
             4311,  # 'type cast': pointer truncation from 'HKL' to 'UINT'
-            4530,  # C++ exception handler used, but unwind semantics are not enabled
+            4530,  # C++ exception handler used, but unwind semantics are not
+                   # enabled
             4506,  # no definition for inline function
             4577,  # 'noexcept' used with no exception handling mode specified
             4996,  # function was declared deprecated
@@ -58,6 +69,7 @@
             "src/keyboard-layout-manager-linux.cc",
           ],
           "include_dirs": [
+            "<!(node -p \"require('node-addon-api').include_dir\")",
             "/usr/local/include", "/usr/local/include/X11",
           ],
           "ldflags": [

--- a/binding.gyp
+++ b/binding.gyp
@@ -58,6 +58,7 @@
                     "sources": [
                         "src/keyboard-layout-manager-linux.cc",
                     ],
+                    "cflags_cc": ["-std=c++17"],
                     "variables": {
                         "wayland_available%": "<!(pkg-config --exists wayland-client && echo 1 || echo 0)"
                     },

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,82 +1,97 @@
 {
-  "targets": [
-    {
-      "target_name": "keyboard-layout-manager",
-      "cflags!": ["-fno-exceptions"],
-      "cflags_cc!": ["-fno-exceptions"],
-      "xcode_settings": {
-        "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
-        "CLANG_CXX_LIBRARY": "libc++",
-        "MACOSX_DEPLOYMENT_TARGET": "10.7",
-      },
-      "msvs_settings": {
-        "VCCLCompilerTool": {"ExceptionHandling": 1},
-      },
-      "sources": [
-        "src/keyboard-layout-manager.cc"
-      ],
-      "include_dirs": [
-        "<!(node -p \"require('node-addon-api').include_dir\")",
-        "chrome_headers",
-      ],
-      "conditions": [
-        ['OS=="mac"', {
-          "sources": [
-            "src/keyboard-layout-manager-mac.mm",
-          ],
-          "link_settings": {
-            "libraries": [
-              "-framework", "AppKit"
-            ]
-          }
-        }],  # OS=="mac"
-        ['OS=="win"', {
-          "sources": [
-            "src/keyboard-layout-manager-windows.cc",
-          ],
-          'msvs_settings': {
-            'VCCLCompilerTool': {
-              'ExceptionHandling': 1,  # /EHsc
-              'WarnAsError': 'true',
+    "targets": [
+        {
+            "target_name": "keyboard-layout-manager",
+            "cflags!": ["-fno-exceptions"],
+            "cflags_cc!": ["-fno-exceptions"],
+            "xcode_settings": {
+                "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+                "CLANG_CXX_LIBRARY": "libc++",
+                "MACOSX_DEPLOYMENT_TARGET": "10.7",
             },
-          },
-          'msvs_disabled_warnings': [
-            4309,  # 'static_cast': truncation of constant value
-            4018,  # signed/unsigned mismatch
-            4244,  # conversion from 'type1' to 'type2', possible loss of data
-            4267,  # conversion from 'size_t' to 'type', possible loss of data
-            4302,  # 'type cast': truncation from 'HKL' to 'UINT'
-            4311,  # 'type cast': pointer truncation from 'HKL' to 'UINT'
-            4530,  # C++ exception handler used, but unwind semantics are not
-                   # enabled
-            4506,  # no definition for inline function
-            4577,  # 'noexcept' used with no exception handling mode specified
-            4996,  # function was declared deprecated
-          ],
-        }],  # OS=="win"
-        ['OS=="linux"', {
-          "sources": [
-            "src/keyboard-layout-manager-linux.cc",
-          ],
-          "link_settings": {
-            "libraries": [
-              "-lX11", "-lxkbfile", "-lxkbcommon", "-lwayland-client"
+            "msvs_settings": {
+                "VCCLCompilerTool": {"ExceptionHandling": 1},
+            },
+            "sources": [
+                "src/keyboard-layout-manager.cc"
+            ],
+            "include_dirs": [
+                "<!(node -p \"require('node-addon-api').include_dir\")",
+                "chrome_headers",
+            ],
+            "conditions": [
+                ['OS=="mac"', {
+                    "sources": [
+                        "src/keyboard-layout-manager-mac.mm",
+                    ],
+                    "link_settings": {
+                        "libraries": [
+                            "-framework", "AppKit"
+                        ]
+                    }
+                }],  # OS=="mac"
+                ['OS=="win"', {
+                    "sources": [
+                        "src/keyboard-layout-manager-windows.cc",
+                    ],
+                    'msvs_settings': {
+                        'VCCLCompilerTool': {
+                            'ExceptionHandling': 1,  # /EHsc
+                            'WarnAsError': 'true',
+                        },
+                    },
+                    'msvs_disabled_warnings': [
+                        4309,  # 'static_cast': truncation of constant value
+                        4018,  # signed/unsigned mismatch
+                        4244,  # conversion from 'type1' to 'type2', possible loss of data
+                        4267,  # conversion from 'size_t' to 'type', possible loss of data
+                        4302,  # 'type cast': truncation from 'HKL' to 'UINT'
+                        4311,  # 'type cast': pointer truncation from 'HKL' to 'UINT'
+                        4530,  # C++ exception handler used, but unwind semantics are not
+                        # enabled
+                        4506,  # no definition for inline function
+                        4577,  # 'noexcept' used with no exception handling mode specified
+                        4996,  # function was declared deprecated
+                    ],
+                }],  # OS=="win"
+                ['OS=="linux"', {
+                    "sources": [
+                        "src/keyboard-layout-manager-linux.cc",
+                    ],
+                    "variables": {
+                        "wayland_available%": "<!(pkg-config --exists wayland-client && echo 1 || echo 0)"
+                    },
+                    "conditions": [
+                        ["wayland_available==1", {
+                            "link_settings": {
+                                "libraries": [
+                                    "-lX11", "-lxkbfile", "-lxkbcommon", "-lwayland-client"
+                                ]
+                            },
+                            "defines": [ "HAS_WAYLAND=1" ]
+                        }, {
+                            "link_settings": {
+                                "libraries": [
+                                    "-lX11", "-lxkbfile", "-lxkbcommon"
+                                ]
+                            },
+                            "defines": [ "HAS_WAYLAND=0" ]
+                        }]
+                    ]
+                }],  # OS=="linux"
+                ['OS=="freebsd"', {
+                    "sources": [
+                        "src/keyboard-layout-manager-linux.cc",
+                    ],
+                    "include_dirs": [
+                        "<!(node -p \"require('node-addon-api').include_dir\")",
+                        "/usr/local/include", "/usr/local/include/X11",
+                    ],
+                    "ldflags": [
+                        "-lX11", "-lxkbfile", "-lxkbcommon", "-L/usr/local/lib",
+                    ],
+                }],  # OS=="posix"
             ]
-          }
-        }],  # OS=="linux"
-        ['OS=="freebsd"', {
-          "sources": [
-            "src/keyboard-layout-manager-linux.cc",
-          ],
-          "include_dirs": [
-            "<!(node -p \"require('node-addon-api').include_dir\")",
-            "/usr/local/include", "/usr/local/include/X11",
-          ],
-          "ldflags": [
-            "-lX11", "-lxkbfile", "-lxkbcommon", "-L/usr/local/lib",
-          ],
-        }],  # OS=="posix"
-      ]
-    }
-  ]
+        }
+    ]
 }

--- a/binding.gyp
+++ b/binding.gyp
@@ -60,7 +60,7 @@
           ],
           "link_settings": {
             "libraries": [
-              "-lX11", "-lxkbfile", "-lxkbcommon"
+              "-lX11", "-lxkbfile", "-lxkbcommon", "-lwayland-client"
             ]
           }
         }],  # OS=="linux"

--- a/binding.gyp
+++ b/binding.gyp
@@ -60,7 +60,7 @@
           ],
           "link_settings": {
             "libraries": [
-              "-lX11", "-lxkbfile"
+              "-lX11", "-lxkbfile", "-lxkbcommon"
             ]
           }
         }],  # OS=="linux"
@@ -73,7 +73,7 @@
             "/usr/local/include", "/usr/local/include/X11",
           ],
           "ldflags": [
-            "-lX11", "-lxkbfile", "-L/usr/local/lib",
+            "-lX11", "-lxkbfile", "-lxkbcommon", "-L/usr/local/lib",
           ],
         }],  # OS=="posix"
       ]

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,98 +1,102 @@
 {
-    "targets": [
-        {
-            "target_name": "keyboard-layout-manager",
-            "cflags!": ["-fno-exceptions"],
-            "cflags_cc!": ["-fno-exceptions"],
-            "xcode_settings": {
-                "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
-                "CLANG_CXX_LIBRARY": "libc++",
-                "MACOSX_DEPLOYMENT_TARGET": "10.7",
-            },
-            "msvs_settings": {
-                "VCCLCompilerTool": {"ExceptionHandling": 1},
-            },
-            "sources": [
-                "src/keyboard-layout-manager.cc"
-            ],
-            "include_dirs": [
-                "<!(node -p \"require('node-addon-api').include_dir\")",
-                "chrome_headers",
-            ],
-            "conditions": [
-                ['OS=="mac"', {
-                    "sources": [
-                        "src/keyboard-layout-manager-mac.mm",
-                    ],
-                    "link_settings": {
-                        "libraries": [
-                            "-framework", "AppKit"
-                        ]
-                    }
-                }],  # OS=="mac"
-                ['OS=="win"', {
-                    "sources": [
-                        "src/keyboard-layout-manager-windows.cc",
-                    ],
-                    'msvs_settings': {
-                        'VCCLCompilerTool': {
-                            'ExceptionHandling': 1,  # /EHsc
-                            'WarnAsError': 'true',
-                        },
-                    },
-                    'msvs_disabled_warnings': [
-                        4309,  # 'static_cast': truncation of constant value
-                        4018,  # signed/unsigned mismatch
-                        4244,  # conversion from 'type1' to 'type2', possible loss of data
-                        4267,  # conversion from 'size_t' to 'type', possible loss of data
-                        4302,  # 'type cast': truncation from 'HKL' to 'UINT'
-                        4311,  # 'type cast': pointer truncation from 'HKL' to 'UINT'
-                        4530,  # C++ exception handler used, but unwind semantics are not
-                        # enabled
-                        4506,  # no definition for inline function
-                        4577,  # 'noexcept' used with no exception handling mode specified
-                        4996,  # function was declared deprecated
-                    ],
-                }],  # OS=="win"
-                ['OS=="linux"', {
-                    "sources": [
-                        "src/keyboard-layout-manager-linux.cc",
-                    ],
-                    "cflags_cc": ["-std=c++17"],
-                    "variables": {
-                        "wayland_available%": "<!(pkg-config --exists wayland-client && echo 1 || echo 0)"
-                    },
-                    "conditions": [
-                        ["wayland_available==1", {
-                            "link_settings": {
-                                "libraries": [
-                                    "-lX11", "-lxkbfile", "-lxkbcommon", "-lwayland-client"
-                                ]
-                            },
-                            "defines": [ "HAS_WAYLAND=1" ]
-                        }, {
-                            "link_settings": {
-                                "libraries": [
-                                    "-lX11", "-lxkbfile", "-lxkbcommon"
-                                ]
-                            },
-                            "defines": [ "HAS_WAYLAND=0" ]
-                        }]
-                    ]
-                }],  # OS=="linux"
-                ['OS=="freebsd"', {
-                    "sources": [
-                        "src/keyboard-layout-manager-linux.cc",
-                    ],
-                    "include_dirs": [
-                        "<!(node -p \"require('node-addon-api').include_dir\")",
-                        "/usr/local/include", "/usr/local/include/X11",
-                    ],
-                    "ldflags": [
-                        "-lX11", "-lxkbfile", "-lxkbcommon", "-L/usr/local/lib",
-                    ],
-                }],  # OS=="posix"
+  "targets": [
+    {
+      "target_name": "keyboard-layout-manager",
+      "cflags!": ["-fno-exceptions"],
+      "cflags_cc!": ["-fno-exceptions"],
+      "xcode_settings": {
+        "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+        "CLANG_CXX_LIBRARY": "libc++",
+        "MACOSX_DEPLOYMENT_TARGET": "10.7",
+      },
+      "msvs_settings": {
+        "VCCLCompilerTool": {"ExceptionHandling": 1},
+      },
+      "sources": [
+        "src/keyboard-layout-manager.cc"
+      ],
+      "include_dirs": [
+        "<!(node -p \"require('node-addon-api').include_dir\")",
+        "chrome_headers",
+      ],
+      "conditions": [
+        ['OS=="mac"', {
+          "sources": [
+            "src/keyboard-layout-manager-mac.mm",
+          ],
+          "link_settings": {
+            "libraries": [
+              "-framework", "AppKit"
             ]
-        }
-    ]
+          }
+        }],  # OS=="mac"
+        ['OS=="win"', {
+          "sources": [
+            "src/keyboard-layout-manager-windows.cc",
+          ],
+          'msvs_settings': {
+            'VCCLCompilerTool': {
+              'ExceptionHandling': 1,  # /EHsc
+              'WarnAsError': 'true',
+            },
+          },
+          'msvs_disabled_warnings': [
+            4309,  # 'static_cast': truncation of constant value
+            4018,  # signed/unsigned mismatch
+            4244,  # conversion from 'type1' to 'type2', possible loss of data
+            4267,  # conversion from 'size_t' to 'type', possible loss of data
+            4302,  # 'type cast': truncation from 'HKL' to 'UINT'
+            4311,  # 'type cast': pointer truncation from 'HKL' to 'UINT'
+            4530,  # C++ exception handler used, but unwind semantics are not
+            # enabled
+            4506,  # no definition for inline function
+            4577,  # 'noexcept' used with no exception handling mode specified
+            4996,  # function was declared deprecated
+          ],
+        }],  # OS=="win"
+        ['OS=="linux"', {
+          "sources": [
+            "src/keyboard-layout-manager-linux.cc",
+          ],
+          "cflags_cc": ["-std=c++17"],
+          "variables": {
+            "wayland_available%": "<!(pkg-config --exists wayland-client && echo 1 || echo 0)"
+          },
+          "conditions": [
+            ["wayland_available==1", {
+              "link_settings": {
+                "libraries": [
+                  "-lX11",
+                  "-lxkbfile",
+                  "-lxkbcommon",
+                  "-lwayland-client"
+                ]
+              },
+              "defines": ["HAS_WAYLAND=1"]
+            }, {
+              "link_settings": {
+                "libraries": [
+                  "-lX11",
+                  "-lxkbfile"
+                ]
+              },
+              "defines": ["HAS_WAYLAND=0"]
+            }]
+          ]
+        }],  # OS=="linux"
+        ['OS=="freebsd"', {
+          "sources": [
+            "src/keyboard-layout-manager-linux.cc",
+          ],
+          "include_dirs": [
+            "<!(node -p \"require('node-addon-api').include_dir\")",
+            "/usr/local/include", "/usr/local/include/X11",
+          ],
+          "ldflags": [
+            "-lX11", "-lxkbfile", "-lxkbcommon", "-L/usr/local/lib",
+          ],
+        }],  # OS=="posix"
+      ]
+    }
+  ]
 }

--- a/lib/keyboard-layout.js
+++ b/lib/keyboard-layout.js
@@ -22,9 +22,7 @@ function getCurrentKeymap () {
 }
 
 function getCurrentKeyboardLayout () {
-   let result = manager.getCurrentKeyboardLayout()
-   console.log('AHA!', result);
-   return result
+   return manager.getCurrentKeyboardLayout()
 }
 
 function getCurrentKeyboardLanguage () {

--- a/lib/keyboard-layout.js
+++ b/lib/keyboard-layout.js
@@ -29,13 +29,13 @@ function getCurrentKeyboardLanguage () {
 }
 
 function getInstalledKeyboardLanguages () {
-  var languages = {}
+  var languages = new Set();
 
   for (var language of (manager.getInstalledKeyboardLanguages() || [])) {
-    languages[language] = true
+    languages.add(language)
   }
 
-  return Object.keys(languages)
+  return Array.from(languages)
 }
 
 function onDidChangeCurrentKeyboardLayout (callback) {

--- a/lib/keyboard-layout.js
+++ b/lib/keyboard-layout.js
@@ -7,7 +7,7 @@ const emitter = new Emitter()
 const keymapsByLayoutName = new Map()
 
 const manager = new KeyboardLayoutManager((...args) => {
-  console.log('Callback!!!! arg0:', args[0]);
+  console.log('Callback!!!! arg0:', args[0], 'length???', args.length);
   emitter.emit('did-change-current-keyboard-layout', args[0])
 })
 

--- a/lib/keyboard-layout.js
+++ b/lib/keyboard-layout.js
@@ -7,7 +7,7 @@ const emitter = new Emitter()
 const keymapsByLayoutName = new Map()
 
 const manager = new KeyboardLayoutManager((current) => {
-  emitter.emit('did-change-current-keyboard-layout', getCurrentKeyboardLayout(current))
+  emitter.emit('did-change-current-keyboard-layout', current)
 })
 
 function getCurrentKeymap () {

--- a/lib/keyboard-layout.js
+++ b/lib/keyboard-layout.js
@@ -6,9 +6,9 @@ const { KeyboardLayoutManager } = require('../build/Release/keyboard-layout-mana
 const emitter = new Emitter()
 const keymapsByLayoutName = new Map()
 
-const manager = new KeyboardLayoutManager((...args) => {
-  console.log('Callback!!!! arg0:', args[0], 'length???', args.length);
-  emitter.emit('did-change-current-keyboard-layout', args[0])
+const manager = new KeyboardLayoutManager(() => {
+  let current = getCurrentKeyboardLayout();
+  emitter.emit('did-change-current-keyboard-layout', current)
 })
 
 function getCurrentKeymap () {

--- a/lib/keyboard-layout.js
+++ b/lib/keyboard-layout.js
@@ -21,7 +21,9 @@ function getCurrentKeymap () {
 }
 
 function getCurrentKeyboardLayout () {
-   return manager.getCurrentKeyboardLayout()
+   let result = manager.getCurrentKeyboardLayout()
+   console.log('AHA!', result);
+   return result
 }
 
 function getCurrentKeyboardLanguage () {
@@ -47,7 +49,28 @@ function observeCurrentKeyboardLayout (callback) {
   return onDidChangeCurrentKeyboardLayout(callback)
 }
 
+// Add this to your KeyboardLayout JS wrapper
+function diagnose() {
+  // Get a list of active handles
+  const activeHandles = process._getActiveHandles();
+  console.log('Active handles:', activeHandles.length);
+  activeHandles.forEach((handle, i) => {
+    console.log(`Handle ${i}:`, handle.constructor.name);
+  });
+
+  // Get active requests
+  const activeRequests = process._getActiveRequests();
+  console.log('Active requests:', activeRequests.length);
+
+  // Force a garbage collection (if --expose-gc is enabled)
+  if (global.gc) {
+    console.log('Forcing garbage collection...');
+    global.gc();
+  }
+}
+
 module.exports = {
+  diagnose,
   getCurrentKeymap,
   getCurrentKeyboardLayout,
   getCurrentKeyboardLanguage,

--- a/lib/keyboard-layout.js
+++ b/lib/keyboard-layout.js
@@ -48,10 +48,10 @@ function observeCurrentKeyboardLayout (callback) {
 }
 
 module.exports = {
-  getCurrentKeymap: getCurrentKeymap,
-  getCurrentKeyboardLayout: getCurrentKeyboardLayout,
-  getCurrentKeyboardLanguage: getCurrentKeyboardLanguage,
-  getInstalledKeyboardLanguages: getInstalledKeyboardLanguages,
-  onDidChangeCurrentKeyboardLayout: onDidChangeCurrentKeyboardLayout,
-  observeCurrentKeyboardLayout: observeCurrentKeyboardLayout
+  getCurrentKeymap,
+  getCurrentKeyboardLayout,
+  getCurrentKeyboardLanguage,
+  getInstalledKeyboardLanguages,
+  onDidChangeCurrentKeyboardLayout,
+  observeCurrentKeyboardLayout
 }

--- a/lib/keyboard-layout.js
+++ b/lib/keyboard-layout.js
@@ -6,8 +6,9 @@ const { KeyboardLayoutManager } = require('../build/Release/keyboard-layout-mana
 const emitter = new Emitter()
 const keymapsByLayoutName = new Map()
 
-const manager = new KeyboardLayoutManager((current) => {
-  emitter.emit('did-change-current-keyboard-layout', current)
+const manager = new KeyboardLayoutManager((...args) => {
+  console.log('Callback!!!! args:', ...args);
+  emitter.emit('did-change-current-keyboard-layout', ...args)
 })
 
 function getCurrentKeymap () {

--- a/lib/keyboard-layout.js
+++ b/lib/keyboard-layout.js
@@ -6,8 +6,8 @@ const { KeyboardLayoutManager } = require('../build/Release/keyboard-layout-mana
 const emitter = new Emitter()
 const keymapsByLayoutName = new Map()
 
-const manager = new KeyboardLayoutManager(() => {
-  emitter.emit('did-change-current-keyboard-layout', getCurrentKeyboardLayout())
+const manager = new KeyboardLayoutManager((current) => {
+  emitter.emit('did-change-current-keyboard-layout', getCurrentKeyboardLayout(current))
 })
 
 function getCurrentKeymap () {

--- a/lib/keyboard-layout.js
+++ b/lib/keyboard-layout.js
@@ -7,8 +7,8 @@ const emitter = new Emitter()
 const keymapsByLayoutName = new Map()
 
 const manager = new KeyboardLayoutManager((...args) => {
-  console.log('Callback!!!! args:', ...args);
-  emitter.emit('did-change-current-keyboard-layout', ...args)
+  console.log('Callback!!!! arg0:', args[0]);
+  emitter.emit('did-change-current-keyboard-layout', args[0])
 })
 
 function getCurrentKeymap () {

--- a/lib/keyboard-layout.js
+++ b/lib/keyboard-layout.js
@@ -48,28 +48,7 @@ function observeCurrentKeyboardLayout (callback) {
   return onDidChangeCurrentKeyboardLayout(callback)
 }
 
-// Add this to your KeyboardLayout JS wrapper
-function diagnose() {
-  // Get a list of active handles
-  const activeHandles = process._getActiveHandles();
-  console.log('Active handles:', activeHandles.length);
-  activeHandles.forEach((handle, i) => {
-    console.log(`Handle ${i}:`, handle.constructor.name);
-  });
-
-  // Get active requests
-  const activeRequests = process._getActiveRequests();
-  console.log('Active requests:', activeRequests.length);
-
-  // Force a garbage collection (if --expose-gc is enabled)
-  if (global.gc) {
-    console.log('Forcing garbage collection...');
-    global.gc();
-  }
-}
-
 module.exports = {
-  diagnose,
   getCurrentKeymap,
   getCurrentKeyboardLayout,
   getCurrentKeyboardLanguage,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.17",
       "dependencies": {
         "event-kit": "^2.0.0",
-        "node-addon-api": "^6.1.0"
+        "node-addon-api": "^7.1.1"
       },
       "devDependencies": {
         "jasmine-focused": "^1.0.4"
@@ -333,9 +333,9 @@
       "dev": true
     },
     "node_modules/node-addon-api": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
-      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT"
     },
     "node_modules/once": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.17",
       "dependencies": {
         "event-kit": "^2.0.0",
-        "node-addon-api": "^7.1.1"
+        "node-addon-api": "^6.1.0"
       },
       "devDependencies": {
         "jasmine-focused": "^1.0.4"
@@ -333,9 +333,9 @@
       "dev": true
     },
     "node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
       "license": "MIT"
     },
     "node_modules/once": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "2.0.17",
       "dependencies": {
         "event-kit": "^2.0.0",
-        "nan": "^2.13.2",
-        "node-addon-api": "^8.2.1"
+        "node-addon-api": "^7.1.1"
       },
       "devDependencies": {
         "jasmine-focused": "^1.0.4"
@@ -333,19 +332,11 @@
       "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
       "dev": true
     },
-    "node_modules/nan": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
-    },
     "node_modules/node-addon-api": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.2.1.tgz",
-      "integrity": "sha512-vmEOvxwiH8tlOcv4SyE8RH34rI5/nWVaigUeAUPawC6f0+HoDthwI0vkMu4tbtsZrXq6QXFfrkhjofzKEs5tpA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^18 || ^20 || >= 21"
-      }
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
     },
     "node_modules/once": {
       "version": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,217 +1,271 @@
 {
   "name": "keyboard-layout",
   "version": "2.0.17",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "amdefine": {
+  "packages": {
+    "": {
+      "name": "keyboard-layout",
+      "version": "2.0.17",
+      "dependencies": {
+        "event-kit": "^2.0.0",
+        "nan": "^2.13.2",
+        "node-addon-api": "^8.2.1"
+      },
+      "devDependencies": {
+        "jasmine-focused": "^1.0.4"
+      }
+    },
+    "node_modules/amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.2"
+      }
     },
-    "async": {
+    "node_modules/async": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
-    "balanced-match": {
+    "node_modules/balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "brace-expansion": {
+    "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
-    "coffee-script": {
+    "node_modules/coffee-script": {
       "version": "1.12.7",
       "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
       "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
-      "dev": true
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "dev": true,
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
-    "coffeestack": {
+    "node_modules/coffeestack": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/coffeestack/-/coffeestack-1.1.2.tgz",
       "integrity": "sha1-NSePO+uc5vXQraH7bgh4UrZXzpg=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "coffee-script": "~1.8.0",
         "fs-plus": "^2.5.0",
         "source-map": "~0.1.43"
-      },
-      "dependencies": {
-        "coffee-script": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.8.0.tgz",
-          "integrity": "sha1-nJ8dK0pSoADe0Vtll5FwNkgmPB0=",
-          "dev": true,
-          "requires": {
-            "mkdirp": "~0.3.5"
-          }
-        }
       }
     },
-    "concat-map": {
+    "node_modules/coffeestack/node_modules/coffee-script": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.8.0.tgz",
+      "integrity": "sha1-nJ8dK0pSoADe0Vtll5FwNkgmPB0=",
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "dev": true,
+      "dependencies": {
+        "mkdirp": "~0.3.5"
+      },
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "event-kit": {
+    "node_modules/event-kit": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/event-kit/-/event-kit-2.5.0.tgz",
       "integrity": "sha512-tUDxeNC9JzN2Tw/f8mLtksY34v1hHmaR7lV7X4p04XSjaeUhFMfzjF6Nwov9e0EKGEx63BaKcgXKxjpQaPo0wg=="
     },
-    "fileset": {
+    "node_modules/fileset": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.8.tgz",
       "integrity": "sha1-UGuRqTluqn4y+0KoQHfHoMc2t0E=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "glob": "3.x",
         "minimatch": "0.x"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "3.2.11",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-          "dev": true,
-          "requires": {
-            "inherits": "2",
-            "minimatch": "0.3"
-          },
-          "dependencies": {
-            "minimatch": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-              "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-              "dev": true,
-              "requires": {
-                "lru-cache": "2",
-                "sigmund": "~1.0.0"
-              }
-            }
-          }
-        },
-        "minimatch": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
-          "integrity": "sha1-vSx9Bg0sjI/Xzefx8u0tWycP2xs=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
-          }
-        }
       }
     },
-    "fs-plus": {
+    "node_modules/fileset/node_modules/glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "inherits": "2",
+        "minimatch": "0.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/fileset/node_modules/glob/node_modules/minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/fileset/node_modules/minimatch": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
+      "integrity": "sha1-vSx9Bg0sjI/Xzefx8u0tWycP2xs=",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/fs-plus": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-2.10.1.tgz",
       "integrity": "sha1-MgR4HXhAYR5jZOe2+wWMljJ8WqU=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "async": "^1.5.2",
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.2",
         "underscore-plus": "1.x"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        }
       }
     },
-    "fs.realpath": {
+    "node_modules/fs-plus/node_modules/mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dev": true,
+      "dependencies": {
+        "minimist": "0.0.8"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "gaze": {
+    "node_modules/gaze": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.3.4.tgz",
       "integrity": "sha1-X5S92gr+U7xxCWm81vKCVI1gwnk=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "fileset": "~0.1.5",
         "minimatch": "~0.2.9"
       },
-      "dependencies": {
-        "minimatch": {
-          "version": "0.2.14",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
-          }
-        }
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
-    "glob": {
+    "node_modules/gaze/node_modules/minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "inflight": {
+    "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
       }
     },
-    "inherits": {
+    "node_modules/inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
-    "jasmine-focused": {
+    "node_modules/jasmine-focused": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/jasmine-focused/-/jasmine-focused-1.0.7.tgz",
       "integrity": "sha1-uDx1fIAOaOHW78GjoaE/85/23NI=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "jasmine-node": "git+https://github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef",
         "underscore-plus": "1.x",
         "walkdir": "0.0.7"
+      },
+      "bin": {
+        "jasmine-focused": "bin/jasmine-focused",
+        "nof": "bin/nof"
       }
     },
-    "jasmine-node": {
-      "version": "git+https://github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef",
-      "from": "git+https://github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef",
+    "node_modules/jasmine-node": {
+      "version": "1.10.2",
+      "resolved": "git+ssh://git@github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef",
+      "integrity": "sha512-V/IgVMSqSgd8oYJBLIqErFhioPT4NuHQqkU0s2MLWHpUoarw90qFHJ1WZ7cQXhtEnqLSAPoFgzD9pVCH/j2aPg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "coffee-script": ">=1.0.1",
         "coffeestack": ">=1 <2",
         "gaze": "~0.3.2",
@@ -220,146 +274,186 @@
         "requirejs": ">=0.27.1",
         "underscore": ">= 1.3.1",
         "walkdir": ">= 0.0.1"
+      },
+      "bin": {
+        "jasmine-node": "bin/jasmine-node"
       }
     },
-    "jasmine-reporters": {
+    "node_modules/jasmine-reporters": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/jasmine-reporters/-/jasmine-reporters-2.3.2.tgz",
       "integrity": "sha512-u/7AT9SkuZsUfFBLLzbErohTGNsEUCKaQbsVYnLFW1gEuL2DzmBL4n8v90uZsqIqlWvWUgian8J6yOt5Fyk/+A==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "mkdirp": "^0.5.1",
         "xmldom": "^0.1.22"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        }
       }
     },
-    "lru-cache": {
+    "node_modules/jasmine-reporters/node_modules/mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dev": true,
+      "dependencies": {
+        "minimist": "0.0.8"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/lru-cache": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
       "dev": true
     },
-    "minimatch": {
+    "node_modules/minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "minimist": {
+    "node_modules/minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
-    "mkdirp": {
+    "node_modules/mkdirp": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
       "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
       "dev": true
     },
-    "nan": {
+    "node_modules/nan": {
       "version": "2.13.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
       "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
     },
-    "once": {
+    "node_modules/node-addon-api": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.2.1.tgz",
+      "integrity": "sha512-vmEOvxwiH8tlOcv4SyE8RH34rI5/nWVaigUeAUPawC6f0+HoDthwI0vkMu4tbtsZrXq6QXFfrkhjofzKEs5tpA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "wrappy": "1"
       }
     },
-    "path-is-absolute": {
+    "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "requirejs": {
+    "node_modules/requirejs": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.5.tgz",
       "integrity": "sha512-svnO+aNcR/an9Dpi44C7KSAy5fFGLtmPbaaCeQaklUz8BQhS64tWWIIlvEA5jrWICzlO/X9KSzSeXFnZdBu8nw==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "r_js": "bin/r.js",
+        "r.js": "bin/r.js"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
-    "rimraf": {
+    "node_modules/rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "glob": "^7.0.5"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
-    "sigmund": {
+    "node_modules/sigmund": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
       "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
       "dev": true
     },
-    "source-map": {
+    "node_modules/source-map": {
       "version": "0.1.43",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
       "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "amdefine": ">=0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
-    "underscore": {
+    "node_modules/underscore": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
       "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
       "dev": true
     },
-    "underscore-plus": {
+    "node_modules/underscore-plus": {
       "version": "1.6.8",
       "resolved": "https://registry.npmjs.org/underscore-plus/-/underscore-plus-1.6.8.tgz",
       "integrity": "sha512-88PrCeMKeAAC1L4xjSiiZ3Fg6kZOYrLpLGVPPeqKq/662DfQe/KTSKdSR/Q/tucKNnfW2MNAUGSCkDf8HmXC5Q==",
       "dev": true,
-      "requires": {
-        "underscore": "~1.8.3"
-      },
       "dependencies": {
-        "underscore": {
-          "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-          "dev": true
-        }
+        "underscore": "~1.8.3"
       }
     },
-    "walkdir": {
+    "node_modules/underscore-plus/node_modules/underscore": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+      "dev": true
+    },
+    "node_modules/walkdir": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.7.tgz",
       "integrity": "sha1-BNoCcKh6d4VAFzzb8KLbSZqNnik=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.6.0"
+      }
     },
-    "wrappy": {
+    "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
-    "xmldom": {
+    "node_modules/xmldom": {
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
       "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
-      "dev": true
+      "deprecated": "Deprecated due to CVE-2021-21366 resolved in 0.5.0",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "event-kit": "^2.0.0",
-    "node-addon-api": "^7.1.1"
+    "node-addon-api": "^6.1.0"
   },
   "devDependencies": {
     "jasmine-focused": "^1.0.4"

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     }
   ],
   "dependencies": {
-    "event-kit": "^2.0.0",
-    "nan": "^2.13.2"
+    "node-addon-api": "8.2.1",
+    "event-kit": "^2.0.0"
   },
   "devDependencies": {
     "jasmine-focused": "^1.0.4"

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     }
   ],
   "dependencies": {
-    "node-addon-api": "8.2.1",
-    "event-kit": "^2.0.0"
+    "event-kit": "^2.0.0",
+    "node-addon-api": "^7.1.1"
   },
   "devDependencies": {
     "jasmine-focused": "^1.0.4"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "event-kit": "^2.0.0",
-    "node-addon-api": "^6.1.0"
+    "node-addon-api": "^7.1.1"
   },
   "devDependencies": {
     "jasmine-focused": "^1.0.4"

--- a/spec/keyboard-layout-spec.js
+++ b/spec/keyboard-layout-spec.js
@@ -109,7 +109,9 @@ describe('Keyboard Layout', () => {
 
     describe('.getCurrentKeyboardLayout()', function () {
       it('returns an identifier for the current keyboard layout (basic smoke test)', function () {
-        expect(KeyboardLayout.getCurrentKeyboardLayout()).toBeDefined()
+        let layout = KeyboardLayout.getCurrentKeyboardLayout();
+        console.warn('Linux keyboard layout:', layout);
+        expect(layout).toBeDefined()
       })
     })
   }

--- a/spec/keyboard-layout-spec.js
+++ b/spec/keyboard-layout-spec.js
@@ -108,12 +108,12 @@ describe('Keyboard Layout', () => {
       })
     })
 
-    describe('.getCurrentKeyboardLayout()', function () {
-      it('returns an identifier for the current keyboard layout (basic smoke test)', function () {
-        let layout = KeyboardLayout.getCurrentKeyboardLayout();
-        console.warn('Linux keyboard layout:', layout);
-        expect(layout).toBeDefined()
-      })
-    })
+    // describe('.getCurrentKeyboardLayout()', function () {
+    //   it('returns an identifier for the current keyboard layout (basic smoke test)', function () {
+    //     let layout = KeyboardLayout.getCurrentKeyboardLayout();
+    //     console.warn('Linux keyboard layout:', layout);
+    //     expect(layout).toBeDefined()
+    //   })
+    // })
   }
 })

--- a/spec/keyboard-layout-spec.js
+++ b/spec/keyboard-layout-spec.js
@@ -99,13 +99,14 @@ describe('Keyboard Layout', () => {
 
   // Smoke tests on Linux
   if (process.platform === 'linux') {
-    // describe('.getCurrentKeymap()', function () {
-    //   it('returns a keymap with unmodified and shift-modified keys without blowing up (basic smoke test)', function () {
-    //     const keymap = KeyboardLayout.getCurrentKeymap()
-    //     expect(keymap.KeyG.unmodified).toBeDefined()
-    //     expect(keymap.KeyG.withShift).toBeDefined()
-    //   })
-    // })
+    describe('.getCurrentKeymap()', function () {
+      it('returns a keymap with unmodified and shift-modified keys without blowing up (basic smoke test)', function () {
+        const keymap = KeyboardLayout.getCurrentKeymap()
+        console.log('KEYMAP:', keymap);
+        expect(keymap.KeyG.unmodified).toBeDefined()
+        expect(keymap.KeyG.withShift).toBeDefined()
+      })
+    })
 
     describe('.getCurrentKeyboardLayout()', function () {
       it('returns an identifier for the current keyboard layout (basic smoke test)', function () {

--- a/spec/keyboard-layout-spec.js
+++ b/spec/keyboard-layout-spec.js
@@ -108,12 +108,12 @@ describe('Keyboard Layout', () => {
       })
     })
 
-    // describe('.getCurrentKeyboardLayout()', function () {
-    //   it('returns an identifier for the current keyboard layout (basic smoke test)', function () {
-    //     let layout = KeyboardLayout.getCurrentKeyboardLayout();
-    //     console.warn('Linux keyboard layout:', layout);
-    //     expect(layout).toBeDefined()
-    //   })
-    // })
+    describe('.getCurrentKeyboardLayout()', function () {
+      it('returns an identifier for the current keyboard layout (basic smoke test)', function () {
+        let layout = KeyboardLayout.getCurrentKeyboardLayout();
+        console.warn('Linux keyboard layout:', layout);
+        expect(layout).toBeDefined()
+      })
+    })
   }
 })

--- a/spec/keyboard-layout-spec.js
+++ b/spec/keyboard-layout-spec.js
@@ -99,13 +99,13 @@ describe('Keyboard Layout', () => {
 
   // Smoke tests on Linux
   if (process.platform === 'linux') {
-    describe('.getCurrentKeymap()', function () {
-      it('returns a keymap with unmodified and shift-modified keys without blowing up (basic smoke test)', function () {
-        const keymap = KeyboardLayout.getCurrentKeymap()
-        expect(keymap.KeyG.unmodified).toBeDefined()
-        expect(keymap.KeyG.withShift).toBeDefined()
-      })
-    })
+    // describe('.getCurrentKeymap()', function () {
+    //   it('returns a keymap with unmodified and shift-modified keys without blowing up (basic smoke test)', function () {
+    //     const keymap = KeyboardLayout.getCurrentKeymap()
+    //     expect(keymap.KeyG.unmodified).toBeDefined()
+    //     expect(keymap.KeyG.withShift).toBeDefined()
+    //   })
+    // })
 
     describe('.getCurrentKeyboardLayout()', function () {
       it('returns an identifier for the current keyboard layout (basic smoke test)', function () {

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -47,7 +47,7 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
   }
 }
 
-KeyboardLayoutManager::PlatformTeardown() {
+void KeyboardLayoutManager::PlatformTeardown() {
   if (xInputContext) {
     XDestroyIC(xInputContext);
   }
@@ -64,6 +64,7 @@ void KeyboardLayoutManager::HandleKeyboardLayoutChanged() {
 }
 
 Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::CallbackInfo& info) {
+  auto env = info.Env();
   Napi::HandleScope scope(env);
   Napi::Value result;
 
@@ -82,8 +83,6 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
   }
 
   return result;
-
-  return;
 }
 
 Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLanguage(const Napi::CallbackInfo& info) {
@@ -92,6 +91,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLanguage(const Napi::Callba
 }
 
 Napi::Value KeyboardLayoutManager::GetInstalledKeyboardLanguages(const Napi::CallbackInfo& info) {
+  auto env = info.Env();
   Napi::HandleScope scope(env);
   return env.Undefined();
 }
@@ -106,7 +106,7 @@ struct KeycodeMapEntry {
 
 #include "keycode_converter_data.inc"
 
-Napi::Value CharacterForNativeCode(XIC xInputContext, XKeyEvent *keyEvent, uint xkbKeycode, uint state) {
+Napi::Value CharacterForNativeCode(Napi::Env env, XIC xInputContext, XKeyEvent *keyEvent, uint xkbKeycode, uint state) {
   keyEvent->keycode = xkbKeycode;
   keyEvent->state = state;
 
@@ -132,6 +132,7 @@ Napi::Value CharacterForNativeCode(XIC xInputContext, XKeyEvent *keyEvent, uint 
 }
 
 Napi::Value KeyboardLayoutManager::GetCurrentKeymap(const Napi::CallbackInfo& info) {
+  auto env = info.Env();
   Napi::Object result = Napi::Object::New(env);
   Napi::String unmodifiedKey = Napi::String::New(env, "unmodified");
   Napi::String withShiftKey = Napi::String::New(env, "withShift");
@@ -162,9 +163,9 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeymap(const Napi::CallbackInfo& in
     uint xkbKeycode = keyCodeMap[i].xkbKeycode;
 
     if (dom3Code && xkbKeycode > 0x0000) {
-      Napi::String dom3CodeKey = Napi::New(env, dom3Code);
-      Napi::Value unmodified = CharacterForNativeCode(xInputContext, keyEvent, xkbKeycode, keyboardBaseState);
-      Napi::Value withShift = CharacterForNativeCode(xInputContext, keyEvent, xkbKeycode, keyboardBaseState | ShiftMask);
+      Napi::String dom3CodeKey = Napi::String::New(env, dom3Code);
+      Napi::Value unmodified = CharacterForNativeCode(env, xInputContext, keyEvent, xkbKeycode, keyboardBaseState);
+      Napi::Value withShift = CharacterForNativeCode(env, xInputContext, keyEvent, xkbKeycode, keyboardBaseState | ShiftMask);
 
       if (unmodified.IsString() || withShift.IsString()) {
         Napi::Object entry = Napi::Object::New(env);

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -115,7 +115,7 @@ Napi::Value CharacterForNativeCode(Napi::Env env, XIC xInputContext, XKeyEvent *
     wchar_t characters[2];
     char utf8[MB_CUR_MAX * 2 + 1];
     int count = XwcLookupString(xInputContext, keyEvent, characters, 2, NULL, NULL);
-    size_t len = wcstombs(utf8, chars, sizeof(utf8));
+    size_t len = wcstombs(utf8, characters, sizeof(utf8));
     if (len == (size_t)-1) {
       return env.Null();
     }
@@ -136,7 +136,7 @@ Napi::Value CharacterForNativeCode(Napi::Env env, XIC xInputContext, XKeyEvent *
     if (count > 0 && !std::iscntrl(characters[0])) {
       return Napi::String::New(
         env,
-        std::string(chars, count)
+        std::string(characters, count)
       );
     } else {
       return env.Null();

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -223,7 +223,6 @@ static void keyboard_repeat_info(void *data, struct wl_keyboard *keyboard,
   // Not used
 }
 
-
 static const struct wl_keyboard_listener keyboard_listener = {
     keyboard_keymap, keyboard_enter,     keyboard_leave,
     keyboard_key,    keyboard_modifiers, keyboard_repeat_info};
@@ -249,7 +248,7 @@ static void CleanupWaylandContext(WaylandKeymapContext *ctx) {
 
 // Given a Wayland context, a keycode, and a modifier mask, return the
 // character that would be produced by that keycode.
-static char *get_key_char(WaylandKeymapContext *ctx, uint32_t keycode,
+static char *GetCharForKeycode(WaylandKeymapContext *ctx, uint32_t keycode,
                           xkb_mod_mask_t modifiers) {
   // At first I thought we needed to offset this by 8, but it already seems
   // correct as-is.
@@ -293,7 +292,7 @@ static Napi::Value WaylandCharacterForCode(Napi::Env env,
                                            WaylandKeymapContext *ctx,
                                            uint32_t keycode,
                                            xkb_mod_mask_t modifiers) {
-  char *result = get_key_char(ctx, keycode, modifiers);
+  char *result = GetCharForKeycode(ctx, keycode, modifiers);
   if (result) {
     auto wrappedResult = Napi::String::New(env, result);
     delete[] result;

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -439,34 +439,6 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeymap(const Napi::CallbackInfo& in
   Napi::String withShiftKey = Napi::String::New(env, "withShift");
 
   if (isWayland) {
-
-    const char *xdg_runtime = getenv("XDG_RUNTIME_DIR");
-    if (xdg_runtime);
-
-    // Construct path to the active keymap if it exists
-    std::string keymap_path = std::string(xdg_runtime) + "/keymap";
-    FILE *f = fopen(keymap_path.c_str(), "r");
-    if (!f) return false;
-
-    // Read the keymap string
-    fseek(f, 0, SEEK_END);
-    long size = ftell(f);
-    fseek(f, 0, SEEK_SET);
-
-
-    char *keymap_string = new char[size + 1];
-    fread(keymap_string, 1, size, f);
-    keymap_string[size] = '\0';
-    fclose(f);
-
-    // Create keymap from the string
-    *keymap = xkb_keymap_new_from_string(context, keymap_string,
-                                        XKB_KEYMAP_FORMAT_TEXT_V1,
-                                        XKB_KEYMAP_COMPILE_NO_FLAGS);
-
-    delete[] keymap_string;
-    return (*keymap != nullptr);
-
     size_t keyCodeMapSize = sizeof(keyCodeMap) / sizeof(keyCodeMap[0]);
     for (size_t i = 0; i < keyCodeMapSizel i++) {
       const char *dom3Code = keyCodeMap[i].dom3Code;

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -6,6 +6,58 @@
 #include <X11/extensions/XKBrules.h>
 #include <cwctype>
 #include <cctype>
+#include <locale.h>
+
+// Function to get current keyboard layout using xkbcommon
+static char* get_current_layout() {
+    // Set locale to use system defaults
+    setlocale(LC_ALL, "");
+
+    // Create xkb context
+    struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+    if (!context) return strdup("unknown");
+
+    // Get layout from environment or default rules
+    const char *env_layout = getenv("XKB_DEFAULT_LAYOUT");
+    const char *env_rules = getenv("XKB_DEFAULT_RULES");
+    const char *env_model = getenv("XKB_DEFAULT_MODEL");
+    const char *env_variant = getenv("XKB_DEFAULT_VARIANT");
+    const char *env_options = getenv("XKB_DEFAULT_OPTIONS");
+
+    struct xkb_rule_names names = {
+        .rules = env_rules,
+        .model = env_model,
+        .layout = env_layout,
+        .variant = env_variant,
+        .options = env_options
+    };
+
+    // Create keymap from names
+    struct xkb_keymap *keymap =
+        xkb_keymap_new_from_names(context, &names, XKB_KEYMAP_COMPILE_NO_FLAGS);
+
+    // Default result
+    char *result = strdup("unknown");
+
+    if (keymap) {
+        // Get the number of layouts (groups)
+        xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(keymap);
+
+        if (num_layouts > 0) {
+            // Get the name of the first layout
+            const char *layout_name = xkb_keymap_layout_get_name(keymap, 0);
+            if (layout_name) {
+                free(result);
+                result = strdup(layout_name);
+            }
+        }
+
+        xkb_keymap_unref(keymap);
+    }
+
+    xkb_context_unref(context);
+    return result;
+}
 
 // More robust detection combining multiple checks
 static int detect_display_server() {
@@ -125,18 +177,27 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
     setlocale(LC_ALL, "");
     struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
     if (context) {
+      // Get layout from environment or default rules
+      const char *env_layout = getenv("XKB_DEFAULT_LAYOUT");
+      const char *env_rules = getenv("XKB_DEFAULT_RULES");
+      const char *env_model = getenv("XKB_DEFAULT_MODEL");
+      const char *env_variant = getenv("XKB_DEFAULT_VARIANT");
+      const char *env_options = getenv("XKB_DEFAULT_OPTIONS");
+
       struct xkb_rule_names names = {
-        .rules = NULL,
-        .model = NULL,
-        .layout = NULL,
-        .variant = NULL,
-        .options = NULL
+        .rules = env_rules,
+        .model = env_model,
+        .layout = env_layout,
+        .variant = env_variant,
+        .options = env_options
       };
+
       struct xkb_keymap *keymap = xkb_keymap_new_from_names(
         context,
         &names,
         XKB_KEYMAP_COMPILE_NO_FLAGS
       );
+
       if (!keymap) {
         result = env.Null();
       } else {

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -313,9 +313,9 @@ struct KeycodeMapEntry {
 
 Napi::Value CharacterForNativeCodeWayland(
   Napi::Env env,
-  xkb_context xkbContext,
-  xkb_keymap xkbKeymap,
-  xkb_state xkbState
+  xkb_context *xkbContext,
+  xkb_keymap *xkbKeymap,
+  xkb_state *xkbState
 ) {
   if (!xkbContext || !xkbKeymap || !xkbState) {
     return env.Null();

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -155,16 +155,22 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
 }
 
 void KeyboardLayoutManager::PlatformTeardown() {
+  std::cout << "Teardown!" << std::endl;
   if (xInputContext) {
     XDestroyIC(xInputContext);
   }
+  std::cout << "Teardown 1" << std::endl;
 
   if (xInputMethod) {
     XCloseIM(xInputMethod);
   }
 
-  XCloseDisplay(xDisplay);
+  std::cout << "Teardown 2" << std::endl;
+  if (xDisplay) {
+    XCloseDisplay(xDisplay);
+  }
   callback.Reset();
+  std::cout << "Teardown 3" << std::endl;
 };
 
 void KeyboardLayoutManager::HandleKeyboardLayoutChanged() {

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -619,5 +619,5 @@ void KeyboardLayoutManager::CleanupWaylandPolling() {
 
 
 void KeyboardLayoutManager::ProcessCallbackWrapper() {
-  ProcessCallback(_env, callback.Value().As<Napi::Function>();
+  ProcessCallback(_env, callback.Value().As<Napi::Function>());
 }

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -344,8 +344,6 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
       return env.Null();
     }
 
-    char layout_id[256] = {0};
-
     xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(waylandContext->xkb_keymap);
     xkb_layout_index_t active_layout = 0;
 
@@ -354,8 +352,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
       return env.Null();
     }
 
-    strcat(layout_id, layout_name);
-    return Napi::String::New(env, layout_name);
+    return Napi::String::New(env, active_layout_name);
   } else {
     // X11
     XkbRF_VarDefsRec vdr;

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -88,6 +88,7 @@ static const struct wl_registry_listener registry_listener = {
 static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
                             uint32_t format, int32_t fd, uint32_t size) {
 
+  std::cout << "in keyboard_keymap" << std::endl;
   // auto env = (static_cast<Napi::Env*>(data));
   // auto that = env->GetInstanceData<KeyboardLayoutManager>();
   auto that = (static_cast<KeyboardLayoutManager *>(data));
@@ -668,14 +669,17 @@ void KeyboardLayoutManager::OnWaylandEvent(uv_poll_t *handle, int status,
       static_cast<KeyboardLayoutManager *>(handle->data);
   if (status < 0) {
     // Error occurred
+    std::cout << "Error! " << status << std::endl;
     return;
   }
 
   if (events & UV_READABLE) {
+    std::cout << "Reading events…" << std::endl;
     // Read events from the display
     wl_display_read_events(instance->waylandContext->display);
 
     // Dispatch pending events
+    std::cout << "Dispatching pending events…" << std::endl;
     wl_display_dispatch_pending(instance->waylandContext->display);
   }
 }

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -380,7 +380,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(Napi::Env env) {
   return Napi::String::New(env, rawResult);
 }
 
-static void KeyboardLayoutManager::ProcessCallback(
+void KeyboardLayoutManager::ProcessCallback(
   Napi::Env env,
   Napi::Function callback
 ) {

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -346,8 +346,11 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
 
     xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(waylandContext->xkb_keymap);
     xkb_layout_index_t active_layout = 0;
+    if (waylandContext->xkb_state) {
+      active_layout_index = xkb_state_serialize_layout(waylandContext->xkb_state);
+    }
 
-    const char* active_layout_name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, i);
+    const char* active_layout_name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, active_layout_index);
     if (!active_layout_name) {
       return env.Null();
     }

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -490,10 +490,10 @@ static char* get_key_char(WaylandKeymapContext *ctx, uint32_t keycode, xkb_mod_m
   xkb_keysym_t keysym = xkb_state_key_get_one_sym(temp_state, xkb_keycode);
 
   // Allocate memory for the result.
-  char *result = new char[32]; // And remember to use delete[] instead of free
+  char *result = new char[32];
 
   // Try to get a UTF-8 representation
-  int len = xkb_keysym_to_utf8(keysym, buffer, 32);
+  int len = xkb_keysym_to_utf8(keysym, result, 32);
 
   if (!result) {
     xkb_state_unref(temp_state);

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -193,18 +193,20 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
   isWayland = true;
 
   if (isWayland) {
-
+    std::cout << "in PlatformSetup!" << std::endl;
     waylandContext = new WaylandKeymapContext();
     memset(waylandContext, 0, sizeof(WaylandKeymapContext));
 
     waylandContext->display = wl_display_connect(NULL);
     if (!waylandContext->display) {
+      std::cout << "Oof 1!" << std::endl;
       FailOnWaylandSetup(env);
       return;
     }
 
     waylandContext->xkb_context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
     if (!waylandContext->xkb_context) {
+      std::cout << "Oof 2!" << std::endl;
       wl_display_disconnect(waylandContext->display);
       FailOnWaylandSetup(env);
       return;
@@ -216,6 +218,8 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
     // Process registry events.
     wl_display_roundtrip(waylandContext->display);
 
+    std::cout << "Got this far 1!" << std::endl;
+
     // If a seat was found, add a keyboard listener.
     if (waylandContext->keyboard) {
       wl_keyboard_add_listener(
@@ -224,11 +228,13 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
         NULL
       );
     } else {
+      std::cout << "Oof 3!" << std::endl;
       CleanupWaylandContext(waylandContext);
       FailOnWaylandSetup(env);
       return;
     }
 
+    std::cout << "Got this far 2!" << std::endl;
     // Wait for the keymap to be received.
     while (!waylandContext->keymap_received) {
       if (wl_display_dispatch(waylandContext->display) < 0) {
@@ -238,6 +244,7 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
       }
     }
 
+    std::cout << "Miracle!" << std::endl;
     // We're good. We can exit.
     return;
   }

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -669,27 +669,3 @@ void KeyboardLayoutManager::CleanupWaylandPolling() {
 void KeyboardLayoutManager::ProcessCallbackWrapper() {
   ProcessCallback(_env, callback.Value().As<Napi::Function>());
 }
-
-
-//////
-
-void print_modifier_info(WaylandKeymapContext* ctx, xkb_mod_index_t mod_idx) {
-    const char* mod_name = xkb_keymap_mod_get_name(ctx->xkb_keymap, mod_idx);
-    fprintf(stderr, "Modifier %d: %s\n", mod_idx, mod_name ? mod_name : "unnamed");
-
-    // List which keys are mapped to this modifier
-    for (xkb_keycode_t keycode = 8; keycode < 256; keycode++) {
-        // Skip if this keycode isn't valid
-        if (!xkb_keymap_key_get_name(ctx->xkb_keymap, keycode)) {
-            continue;
-        }
-
-        // Check if this key affects our modifier
-        if (xkb_keymap_mod_get_mask(ctx->xkb_keymap, mod_idx) &
-            xkb_keymap_key_get_mods_for_key(ctx->xkb_keymap, keycode)) {
-            const char* key_name = xkb_keymap_key_get_name(ctx->xkb_keymap, keycode);
-            fprintf(stderr, "  Key %d (%s) affects this modifier\n",
-                   keycode, key_name ? key_name : "unnamed");
-        }
-    }
-}

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -116,8 +116,8 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
   }
 
   // Try to find AltGr (ISO Level3 Shift) - this varies by layout
-  const char *alt_gr_names[] = {"ISO_Level3_Shift", "Mode_switch", "Alt",
-                                "AltGr"};
+  const char *alt_gr_names[] = {"ISO_Level3_Shift", "Mode_switch",
+                                "AltGr", "Alt"};
 
   size_t alt_gr_length = sizeof(alt_gr_names) / sizeof(alt_gr_names[0]);
   for (size_t i = 0; i < alt_gr_length; i++) {

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -6,6 +6,7 @@
 #include <X11/extensions/XKBrules.h>
 #include <cwctype>
 #include <cctype>
+#include <stdio.h>
 #include <locale.h>
 
 // Function to get current keyboard layout using xkbcommon
@@ -200,12 +201,17 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
       );
 
       if (!keymap) {
+        std::cout << "No keymaps!" << std::endl;
         result = env.Null();
       } else {
+        std::cout << "Keymaps!" << std::endl;
         xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(keymap);
         const char *layout_name = NULL;
         if (num_layouts > 0) {
+          std::cout << "More than one layout!" << std::endl;
           layout_name = xkb_keymap_layout_get_name(keymap, 0);
+
+          std::cout << "Layout name: " << layout_name << std::endl;
 
           // Add null checks before string construction
           std::string layout_str = names.layout ? std::string(names.layout) : "unknown";

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -48,17 +48,11 @@ static int detect_display_server() {
 // =================
 
 static void registry_global(void *data, struct wl_registry *registry, uint32_t name, const char *interface, uint32_t version) {
-  std::cout << "Registry global!" << std::endl;
-  WaylandKeymapContext *ctx = (WaylandKeymapContext *)data;
+  WaylandKeymapContext *ctx = (static_cast<KeyboardLayoutManager *>(manager))->waylandContext;
   if (strcmp(interface, "wl_seat") == 0) {
-    std::cout << "Binding seat!" << std::endl;
     ctx->seat = (struct wl_seat*)wl_registry_bind(registry, name, &wl_seat_interface, 1);
     if (ctx->seat) {
-      std::cout << "Seat bound! Getting keyboard…" << std::endl;
       ctx->keyboard = wl_seat_get_keyboard(ctx->seat);
-      std::cout << "…done!" << std::endl;
-    } else {
-      std::cout << "Failed!" << std::endl;
     }
   }
 }
@@ -71,8 +65,6 @@ static void registry_global_remove(void *data, struct wl_registry *registry,
 static const struct wl_registry_listener registry_listener = {
     registry_global, registry_global_remove};
 
-
-
 // KEYBOARD LISTENER
 // =================
 
@@ -80,8 +72,8 @@ static const struct wl_registry_listener registry_listener = {
 static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
                             uint32_t format, int32_t fd, uint32_t size) {
 
-  std::cout << "In keyboard_keymap!" << std::endl;
-  WaylandKeymapContext *ctx = (WaylandKeymapContext *)data;
+  WaylandKeymapContext *ctx =
+      (static_cast<KeyboardLayoutManager *>(manager))->waylandContext;
 
   if (format != WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1) {
     close(fd);
@@ -93,8 +85,6 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
     close(fd);
     return;
   }
-
-  std::cout << "KEYMAP STRING: " << keymap_string << std::endl;
 
   ctx->xkb_keymap = xkb_keymap_new_from_string(ctx->xkb_context, keymap_string,
                                               XKB_KEYMAP_FORMAT_TEXT_V1,
@@ -133,6 +123,7 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
   }
 
   ctx->keymap_received = true;
+  (static_cast<KeyboardLayoutManager *>(manager))->OnNotificationReceived();
 }
 
 static void keyboard_enter(void *data, struct wl_keyboard *keyboard,
@@ -203,33 +194,25 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
   isWayland = true;
 
   if (isWayland) {
-    std::cout << "in PlatformSetup!" << std::endl;
     waylandContext = new WaylandKeymapContext();
     memset(waylandContext, 0, sizeof(WaylandKeymapContext));
-    std::cout << "memset!" << std::endl;
 
     waylandContext->display = wl_display_connect(NULL);
     if (!waylandContext->display) {
-      std::cout << "Oof 1!" << std::endl;
       FailOnWaylandSetup(env);
       return;
     }
 
-    std::cout << "Got this far 00!" << std::endl;
-
     waylandContext->xkb_context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
     if (!waylandContext->xkb_context) {
-      std::cout << "Oof 2!" << std::endl;
       wl_display_disconnect(waylandContext->display);
       FailOnWaylandSetup(env);
       return;
     }
 
-    std::cout << "Got this far 0!" << std::endl;
-
     waylandContext->registry = wl_display_get_registry(waylandContext->display);
     std::cout << "Listener!" << std::endl;
-    wl_registry_add_listener(waylandContext->registry, &registry_listener, waylandContext);
+    wl_registry_add_listener(waylandContext->registry, &registry_listener, this);
 
     // Process registry events.
     wl_display_roundtrip(waylandContext->display);
@@ -241,7 +224,7 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
       wl_keyboard_add_listener(
         waylandContext->keyboard,
         &keyboard_listener,
-        waylandContext
+        this
       );
     } else {
       std::cout << "Oof 3!" << std::endl;
@@ -259,8 +242,6 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
         return;
       }
     }
-
-    std::cout << "Miracle!" << std::endl;
     // We're good. We can exit.
     return;
   }
@@ -347,172 +328,11 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
       return env.Null();
     }
 
+    // Based on lots of experimentation with Gnome/Wayland, the layout at index
+    // 0 will always be the active layout.
     const char* layout_name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, 0);
 
     result = Napi::String::New(env, layout_name);
-
-
-    // Get layout names - this is usually what you want for identification
-    // char layout_id[256] = {0};
-    //
-    // // Get number of layouts
-    // xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(waylandContext->xkb_keymap);
-    //
-    // // Build a string with all layout names
-    // for (xkb_layout_index_t i = 0; i < num_layouts; i++) {
-    //   const char* layout_name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, i);
-    //   std::cout << "Layout " << i << " is " << layout_name << std::endl;
-    //   if (layout_name) {
-    //     if (i > 0) {
-    //       strcat(layout_id, ",");
-    //     }
-    //     strcat(layout_id, layout_name);
-    //   }
-    // }
-    //
-    // // You could also include the active layout index
-    // // xkb_layout_index_t active_layout = 0;
-    // // if (ctx->xkb_state) {
-    // //   active_layout = xkb_state_serialize_layout(ctx->xkb_state);
-    // // }
-    //
-    // return Napi::String::New(env, layout_id);
-
-
-    // Store the current state
-    // xkb_state* original_state = waylandContext->xkb_state;
-    //
-    // struct xkb_state* temp_state = xkb_state_new(waylandContext->xkb_keymap);
-    // struct xkb_state* temp_state_with_shift = xkb_state_new(waylandContext->xkb_keymap);
-    //
-    // // Get the shift mask
-    // xkb_mod_index_t shift_idx = xkb_keymap_mod_get_index(waylandContext->xkb_keymap, XKB_MOD_NAME_SHIFT);
-    // xkb_mod_mask_t shift_mask = 1 << shift_idx;
-    //
-    // xkb_state_update_mask(temp_state_with_shift, shift_mask, 0, 0, 0, 0 , 0);
-    //
-    // // Create fingerprints for each layout
-    // std::vector<std::string> layout_fingerprints;
-    // xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(waylandContext->xkb_keymap);
-    //
-    //
-    // // For each layout, create a test state
-    // for (xkb_layout_index_t layout = 0; layout < num_layouts; layout++) {
-    //     // Create a new state with just this layout active
-    //     xkb_state* test_state = xkb_state_new(waylandContext->xkb_keymap);
-    //
-    //     // Set the active group (layout)
-    //     xkb_state_update_mask(test_state, 0, 0, 0, layout, 0, 0);
-    //
-    //     // Build a fingerprint of key mappings for this layout
-    //     std::string fingerprint;
-    //     const xkb_keycode_t test_keys[] = { 38, 39, 40 }; // a, s, d
-    //
-    //     for (auto key : test_keys) {
-    //         xkb_keysym_t sym = xkb_state_key_get_one_sym(test_state, key);
-    //         char buf[8] = {0};
-    //         xkb_keysym_to_utf8(sym, buf, sizeof(buf));
-    //         fingerprint += buf;
-    //     }
-    //
-    //     layout_fingerprints.push_back(fingerprint);
-    //     xkb_state_unref(test_state);
-    // }
-    //
-    // // Now get the fingerprint of the current active state
-    // std::string current_fingerprint;
-    // const xkb_keycode_t test_keys[] = {38, 39, 40}; // a, s, d
-    //
-    // for (auto key : test_keys) {
-    //   xkb_keysym_t sym = xkb_state_key_get_one_sym(original_state, key);
-    //   char buf[8] = {0};
-    //   xkb_keysym_to_utf8(sym, buf, sizeof(buf));
-    //   current_fingerprint += buf;
-    // }
-    //
-    // std::cout << "Current fingerprint: " << current_fingerprint << std::endl;
-    //
-    // xkb_state_unref(temp_state);
-    // xkb_state_unref(temp_state_with_shift);
-    //
-    // // Find the matching layout
-    // for (xkb_layout_index_t i = 0; i < layout_fingerprints.size(); i++) {
-    //   if (layout_fingerprints[i] == current_fingerprint) {
-    //     const char *name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, i);
-    //     return Napi::String::New(env, name ? name : std::string("layout-") + std::to_string(i));
-    //     // name ? name : std::string("layout-") + std::to_string(i);
-    //   }
-    // }
-
-    // // Keys to test - include a variety of keys from different parts of keyboard
-    // const xkb_keycode_t test_keys[] = {
-    //   38 + 8, // a
-    //   39 + 8, // s
-    //   40 + 8, // d
-    //   41 + 8, // f
-    //   44 + 8, // j
-    //   45 + 8, // k
-    //   46 + 8, // l
-    //   24 + 8, // q
-    //   25 + 8, // w
-    //   30 + 8, // u
-    //   31 + 8, // i
-    //   32 + 8, // o
-    //   33 + 8, // p
-    //   57 + 8, // space
-    //   28 + 8, // t
-    //   29 + 8, // y
-    //   51 + 8, // hash/pound sign (#)
-    // };
-    //
-    // // Count how many times each layout index responds
-    // std::unordered_map<xkb_layout_index_t, int> layout_scores;
-    //
-    // // Get number of layouts
-    // xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(waylandContext->xkb_keymap);
-    //
-    // for (auto key : test_keys) {
-    //   xkb_layout_index_t layout_index_for_key;
-    //   if (key == 59) {
-    //     layout_index_for_key = xkb_state_key_get_layout(temp_state_with_shift, key);
-    //   } else  {
-    //     layout_index_for_key = xkb_state_key_get_layout(temp_state, key);
-    //   }
-    //   if (layout_index_for_key < num_layouts) {
-    //     layout_scores[layout_index_for_key]++;
-    //   }
-    //   const char* name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, layout_index_for_key);
-    //   std::cout << "Key " << key << " handled by layout " << name << " at index " << layout_index_for_key << std::endl;
-    // }
-    //
-    // std::vector<std::pair<xkb_layout_index_t, int>> score_pairs;
-    // for (const auto &pair : layout_scores) {
-    //   score_pairs.push_back(pair);
-    // }
-    //
-    // // Sort by score (descending)
-    // std::sort(score_pairs.begin(), score_pairs.end(),
-    //           [](const auto &a, const auto &b) { return a.second > b.second; });
-    //
-    // std::stringstream ss;
-    // bool first = true;
-    //
-    // for (const auto &pair : score_pairs) {
-    //   xkb_layout_index_t idx = pair.first;
-    //   int score = pair.second;
-    //
-    //   const char* name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, idx);
-    //   std::string layout_name = name ? name : std::string("layout-") + std::to_string(idx);
-    //
-    //   if (!first) {
-    //     ss << ", ";
-    //   }
-    //   ss << layout_name;
-    //   first = false;
-    // }
-    //
-    //
-    // return Napi::String::New(env, ss.str());
   } else {
     // X11
     XkbRF_VarDefsRec vdr;

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -454,7 +454,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeymap(const Napi::CallbackInfo& in
       if (dom3Code && xkbKeycode > 0x0000) {
         Napi::String dom3CodeKey = Napi::String::New(env, dom3Code);
         Napi::Value unmodified = CharacterForNativeCodeWayland(env, xkbContext, xkbKeymap, xkbState, xkbKeycode, keyboardBaseState);
-        Napi::Value withShift = CharacterForNativeCodeWayland(env, xkbContext, xkbKeymap, xkbState, keyboardBaseState | ShiftMask);
+        Napi::Value withShift = CharacterForNativeCodeWayland(env, xkbContext, xkbKeymap, xkbState, xkbKeycode, keyboardBaseState | ShiftMask);
 
         if (unmodified.IsString() || withShift.IsString()) {
           Napi::Object entry = Napi::Object::New(env);

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -195,7 +195,6 @@ static void CleanupWaylandContext(WaylandKeymapContext* ctx) {
 
 void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
   auto env = info.Env();
-  _env = env;
 
   // isWayland = detect_display_server() == 1;
   isWayland = true;

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -385,6 +385,8 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
       if (layout_index_for_key < num_layouts) {
         layout_scores[layout_index_for_key]++;
       }
+      const char* name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, layout_index_for_key);
+      std::cout << "Key " << key << " handled by layout " << name << std::endl;
     }
 
     std::vector<std::pair<xkb_layout_index_t, int>> score_pairs;

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -349,6 +349,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(Napi::Env env) {
         xkb_keymap_layout_get_name(waylandContext->xkb_keymap, 0);
 
     std::cout << "Current layout: " << layout_name << std::endl;
+    currentLayout = layout_name;
     result = Napi::String::New(env, layout_name);
   } else {
     // X11

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -47,8 +47,10 @@ static int detect_display_server() {
 // =================
 
 static void registry_global(void *data, struct wl_registry *registry, uint32_t name, const char *interface, uint32_t version) {
+  std::cout << "Registry global!" << std::endl;
   WaylandKeymapContext *ctx = (WaylandKeymapContext *)data;
   if (strcmp(interface, "wl_seat") == 0) {
+    std::cout << "Binding seat!" << std::endl;
     ctx->seat = (struct wl_seat*)wl_registry_bind(registry, name, &wl_seat_interface, 1);
     if (ctx->seat) {
       ctx->keyboard = wl_seat_get_keyboard(ctx->seat);
@@ -218,6 +220,7 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
     std::cout << "Got this far 0!" << std::endl;
 
     waylandContext->registry = wl_display_get_registry(waylandContext->display);
+    std::cout << "Listener!" << std::endl;
     wl_registry_add_listener(waylandContext->registry, &registry_listener, NULL);
 
     // Process registry events.

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -10,13 +10,17 @@
 #include <stdio.h>
 #include <sys/mman.h>
 #include <unistd.h>
-#include <xkbcommon/xkbcommon.h>
+#include <optional>
 
 // Enumerates the various modifiers on this keyboard and tests which one brings
 // us to Level 3. This correlates to what we expect from the AltGr key.
-static size_t IndexOfLevel3Modifier(WaylandKeymapContext* ctx) {
+static std::optional<size_t> IndexOfLevel3Modifier(WaylandKeymapContext* ctx) {
+  if (!ctx->xkb_keymap) return std::nullopt;
   struct xkb_state *state = xkb_state_new(ctx->xkb_keymap);
+
+  // Iterate through all the modifiers.
   for (xkb_mod_index_t mod = 0; mod < xkb_keymap_num_mods(ctx->xkb_keymap); mod++) {
+    // Build a mask consisting of just this modifier key.
     xkb_mod_mask_t mask = 1 << mod;
     const char *mod_name = xkb_keymap_mod_get_name(ctx->xkb_keymap, mod);
     xkb_state_update_mask(state, mask, 0, 0, 0, 0, 0);
@@ -24,18 +28,21 @@ static size_t IndexOfLevel3Modifier(WaylandKeymapContext* ctx) {
     bool activates_level3 = false;
     int level3_keys_count = 0;
 
+    // Iterate through all the keycodes and see if any of them correspond to
+    // Level 3 when combined with this modifier.
     for (xkb_keycode_t keycode = 8; keycode < 256; keycode++) {
       if (!xkb_keymap_key_get_name(ctx->xkb_keymap, keycode)) {
         continue;
       }
 
-      xkb_layout_index_t group = 0;
-      xkb_level_index_t level = xkb_state_key_get_level(state, keycode, group);
+      // By observation, index 0 is always the active layout, at least for
+      // GNOME; we hope it's universally true.
+      xkb_layout_index_t active_layout = 0;
+      xkb_level_index_t level = xkb_state_key_get_level(state, keycode, active_layout);
 
+      // Levels are zero-indexed, so “2” is what we expect here.
       if (level == 2) {
-        const char *key_name = xkb_keymap_key_get_name(ctx->xkb_keymap, keycode);
         level3_keys_count++;
-
         if (level3_keys_count >= 3) {
           activates_level3 = true;
           break;
@@ -53,7 +60,7 @@ static size_t IndexOfLevel3Modifier(WaylandKeymapContext* ctx) {
   }
 
   xkb_state_unref(state);
-  return 0;
+  return std::nullopt;
 }
 
 // REGISTRY LISTENER
@@ -140,11 +147,18 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
   // We know that `AltGr` is meant to bring us to keyboard level 3, so we'll
   // try this: loop through the set of modifiers and return the first one that
   // brings us to Level 3 for three or more separate keycodes.
-  size_t alt_gr_index = IndexOfLevel3Modifier(ctx);
+  auto alt_gr_index_result = IndexOfLevel3Modifier(ctx);
 
-  if (alt_gr_index > 0) {
+  if (alt_gr_index_result.has_value()) {
+    size_t alt_gr_index = *alt_gr_index_result;
     ctx->alt_gr_mask = 1 << alt_gr_index;
   } else {
+    // If that approach fails, then we can try a more desperate approach in
+    // which we pick the most likely names for the `AltGr` key and try each of
+    // them in order of likelihood of success. Here we're returning the first
+    // such modifier that exists on this keymap, whether or not it actually
+    // produces the expected result, so it's more speculative than the first
+    // approach.
     const char *alt_gr_names[] = {
         "ISO_Level3_Shift", // Most common for European layouts
         "Mode_switch",      // Often used as an alias
@@ -160,7 +174,9 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
       xkb_mod_index_t idx =
           xkb_keymap_mod_get_index(ctx->xkb_keymap, alt_gr_names[i]);
       if (idx != XKB_MOD_INVALID) {
+#ifdef DEBUG
         std::cout << "Using AltGr name: " << alt_gr_names[i] << std::endl;
+#endif
         ctx->alt_gr_mask = 1 << idx;
         break;
       }
@@ -174,6 +190,7 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
   ctx->keymap_received = true;
 }
 
+// `wayland-client` requires that we
 static void keyboard_enter(void *data, struct wl_keyboard *keyboard,
                            uint32_t serial, struct wl_surface *surface,
                            struct wl_array *keys) {
@@ -232,176 +249,6 @@ static void CleanupWaylandContext(WaylandKeymapContext *ctx) {
   }
 }
 
-void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo &info) {
-  auto env = info.Env();
-
-  // Assume we're on Wayland to start out.
-  isWayland = true;
-
-  waylandContext = new WaylandKeymapContext();
-  memset(waylandContext, 0, sizeof(WaylandKeymapContext));
-
-  waylandContext->display = wl_display_connect(NULL);
-  if (!waylandContext->display) {
-    CleanupWaylandContext(waylandContext);
-    goto x11;
-  }
-
-  waylandContext->xkb_context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
-  if (!waylandContext->xkb_context) {
-    CleanupWaylandContext(waylandContext);
-    goto x11;
-  }
-
-  // If we can get as far as creating a Wayland display and context, it is
-  // assumed that we are on Wayland and not X11. But since any failure further
-  // along the Wayland path of this function is fatal, there's no reason not to
-  // at least _try_ to fallback to X11.
-
-  waylandContext->registry = wl_display_get_registry(waylandContext->display);
-  std::cout << "Listener!" << std::endl;
-  wl_registry_add_listener(waylandContext->registry, &registry_listener,
-                           this);
-
-  // Process registry events.
-  wl_display_roundtrip(waylandContext->display);
-
-  // If a seat was found, add a keyboard listener.
-  if (waylandContext->keyboard) {
-    wl_keyboard_add_listener(waylandContext->keyboard, &keyboard_listener,
-                             this);
-  } else {
-    CleanupWaylandContext(waylandContext);
-    goto x11;
-  }
-
-  // Wait for the keymap to be received.
-  while (!waylandContext->keymap_received) {
-    if (wl_display_dispatch(waylandContext->display) < 0) {
-      CleanupWaylandContext(waylandContext);
-      goto x11;
-    }
-  }
-
-  // Once we've gotten this far, we have everything we need to inspect keyboard
-  // behavior. Now we'll set up polling on the event loop so we can find out
-  // when the keyboard layout changes.
-  SetupWaylandPolling();
-  return;
-
-x11:
-  isWayland = false;
-  xDisplay = XOpenDisplay("");
-  CHECK_VOID(xDisplay, "Could not connect to X display", env);
-
-  xInputMethod = XOpenIM(xDisplay, 0, 0, 0);
-  if (!xInputMethod)
-    return;
-
-  XIMStyles *styles = 0;
-  if (XGetIMValues(xInputMethod, XNQueryInputStyle, &styles, NULL) || !styles) {
-    return;
-  }
-
-  XIMStyle bestMatchStyle = 0;
-  for (int i = 0; i < styles->count_styles; i++) {
-    XIMStyle thisStyle = styles->supported_styles[i];
-    if (thisStyle == (XIMPreeditNothing | XIMStatusNothing)) {
-      bestMatchStyle = thisStyle;
-      break;
-    }
-  }
-  XFree(styles);
-  if (!bestMatchStyle)
-    return;
-
-  Window window;
-  int revert_to;
-  XGetInputFocus(xDisplay, &window, &revert_to);
-  if (window != BadRequest) {
-    xInputContext =
-        XCreateIC(xInputMethod, XNInputStyle, bestMatchStyle, XNClientWindow,
-                  window, XNFocusWindow, window, NULL);
-  }
-}
-
-void KeyboardLayoutManager::PlatformTeardown() {
-  CleanupWaylandPolling();
-  CleanupWaylandContext(waylandContext);
-  callback.Reset();
-};
-
-Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(
-    const Napi::CallbackInfo &info) {
-  auto env = info.Env();
-  Napi::HandleScope scope(env);
-  Napi::Value result;
-
-  if (isWayland) {
-    if (!waylandContext || !waylandContext->xkb_keymap ||
-        !waylandContext->xkb_state) {
-      return env.Null();
-    }
-
-    // Based on lots of experimentation with Gnome/Wayland, the layout at index
-    // 0 will always be the active layout. This may or may not be true for
-    // other Wayland server implementations, but we'll go with it for now —
-    // because if it isn't true, we'd be hard-pressed to discover that
-    // information any other way.
-    const char *layout_name =
-        xkb_keymap_layout_get_name(waylandContext->xkb_keymap, 0);
-
-#ifdef DEBUG
-    std::cout << "Current layout: " << layout_name << std::endl;
-#endif
-    result = Napi::String::New(env, layout_name);
-  } else {
-    // X11
-    XkbRF_VarDefsRec vdr;
-    char *tmp = NULL;
-    if (XkbRF_GetNamesProp(xDisplay, &tmp, &vdr) && vdr.layout) {
-      XkbStateRec xkbState;
-      XkbGetState(xDisplay, XkbUseCoreKbd, &xkbState);
-      if (vdr.variant) {
-        result = Napi::String::New(
-            env, std::string(vdr.layout) + "," + std::string(vdr.variant) +
-                     " [" + std::to_string(xkbState.group) + "]");
-      } else {
-        result =
-            Napi::String::New(env, std::string(vdr.layout) + " [" +
-                                       std::to_string(xkbState.group) + "]");
-      }
-    } else {
-      result = env.Null();
-    }
-  }
-  return result;
-}
-
-Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLanguage(
-    const Napi::CallbackInfo &info) {
-  // No distinction between “language” and “layout” on Linux.
-  return GetCurrentKeyboardLayout(info);
-}
-
-Napi::Value KeyboardLayoutManager::GetInstalledKeyboardLanguages(
-    const Napi::CallbackInfo &info) {
-  auto env = info.Env();
-  Napi::HandleScope scope(env);
-  return env.Undefined();
-}
-
-struct KeycodeMapEntry {
-  uint xkbKeycode;
-  const char *dom3Code;
-};
-
-#define USB_KEYMAP_DECLARATION static const KeycodeMapEntry keyCodeMap[] =
-#define USB_KEYMAP(usb, evdev, xkb, win, mac, code, id)                        \
-  { xkb, code }
-
-#include "keycode_converter_data.inc"
-
 Napi::Value CharacterForNativeCodeWayland(Napi::Env env,
                                           xkb_context *xkbContext,
                                           xkb_keymap *xkbKeymap,
@@ -450,40 +297,8 @@ Napi::Value CharacterForNativeCodeWayland(Napi::Env env,
   }
 }
 
-Napi::Value CharacterForNativeCode(Napi::Env env, XIC xInputContext,
-                                   XKeyEvent *keyEvent, uint xkbKeycode,
-                                   uint state) {
-  keyEvent->keycode = xkbKeycode;
-  keyEvent->state = state;
-
-  if (xInputContext) {
-    wchar_t characters[2];
-    char utf8[MB_CUR_MAX * 2 + 1];
-    int count =
-        XwcLookupString(xInputContext, keyEvent, characters, 2, NULL, NULL);
-    size_t len = wcstombs(utf8, characters, sizeof(utf8));
-    if (len == (size_t)-1) {
-      return env.Null();
-    }
-
-    if (count > 0 && !std::iswcntrl(characters[0])) {
-      return Napi::String::New(env, std::string(utf8, len));
-    } else {
-      return env.Null();
-    }
-  } else {
-    // Graceful fallback for systems where no window is open or no input
-    // context can be found.
-    char characters[2];
-    int count = XLookupString(keyEvent, characters, 2, NULL, NULL);
-    if (count > 0 && !std::iscntrl(characters[0])) {
-      return Napi::String::New(env, std::string(characters, count));
-    } else {
-      return env.Null();
-    }
-  }
-}
-
+// Given a Wayland context, a keycode, and a modifier mask, return the
+// character that would be produced by that keycode.
 static char *get_key_char(WaylandKeymapContext *ctx, uint32_t keycode,
                           xkb_mod_mask_t modifiers) {
   // At first I thought we needed to offset this by 8, but it already seems
@@ -538,6 +353,279 @@ static Napi::Value WaylandCharacterForCode(Napi::Env env,
   }
 }
 
+void KeyboardLayoutManager::SetupWaylandPolling() {
+  if (!waylandContext || !waylandContext->display)
+    return;
+
+  int fd = wl_display_get_fd(waylandContext->display);
+
+  waylandPoll = new uv_poll_t;
+  waylandPoll->data = this;
+
+  uv_poll_init(uv_default_loop(), waylandPoll, fd);
+  uv_poll_start(waylandPoll, UV_READABLE, OnWaylandEvent);
+
+  // Unref the handles so they don't prevent process exit.
+  uv_unref((uv_handle_t *)waylandPoll);
+}
+
+void KeyboardLayoutManager::OnWaylandEvent(uv_poll_t *handle, int status,
+                                           int events) {
+  std::cout << "OnWaylandEvent!" << std::endl;
+  KeyboardLayoutManager *instance =
+      static_cast<KeyboardLayoutManager *>(handle->data);
+  if (status < 0) {
+    // Error occurred
+    std::cout << "Error! " << status << std::endl;
+    return;
+  }
+
+  if (events & UV_READABLE) {
+    std::cout << "Dispatching pending events…" << std::endl;
+    while (wl_display_prepare_read(instance->waylandContext->display) != 0) {
+      wl_display_dispatch_pending(instance->waylandContext->display);
+    }
+    // Now read events (shouldn't block since we've been notified data is
+    // available)
+    if (wl_display_read_events(instance->waylandContext->display) < 0) {
+      std::cout << "ERROR Reading events…" << strerror(errno) << std::endl;
+      return;
+    }
+    // Dispatch the events we just read
+    std::cout << "Dispatching pending events…" << std::endl;
+    wl_display_dispatch_pending(instance->waylandContext->display);
+  }
+}
+
+void KeyboardLayoutManager::CleanupWaylandPolling() {
+  if (waylandPoll) {
+    uv_poll_stop(waylandPoll);
+    uv_close((uv_handle_t *)waylandPoll,
+             [](uv_handle_t *handle) { delete (uv_poll_t *)handle; });
+    waylandPoll = nullptr;
+  }
+}
+
+
+void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo &info) {
+  auto env = info.Env();
+
+#ifdef HAS_WAYLAND
+  // When we're compiled with Wayland support, assume we're on Wayland to start
+  // out, and revert to the X11 approach only if we fail to obtain a keymap via
+  // Wayland APIs.
+  isWayland = true;
+
+  waylandContext = new WaylandKeymapContext();
+  memset(waylandContext, 0, sizeof(WaylandKeymapContext));
+
+  waylandContext->display = wl_display_connect(NULL);
+  if (!waylandContext->display) {
+    CleanupWaylandContext(waylandContext);
+    goto x11;
+  }
+
+  waylandContext->xkb_context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+  if (!waylandContext->xkb_context) {
+    CleanupWaylandContext(waylandContext);
+    goto x11;
+  }
+
+  // If we can get as far as creating a Wayland display and context, it is
+  // assumed that we are on Wayland and not X11. But since any failure further
+  // along the Wayland path of this function is fatal, there's no reason not to
+  // at least _try_ to fallback to X11.
+
+  // Set up registry listeners so that we can discover a seat and a keyboard.
+  waylandContext->registry = wl_display_get_registry(waylandContext->display);
+  wl_registry_add_listener(waylandContext->registry, &registry_listener,
+                           this);
+
+  // Process registry events.
+  wl_display_roundtrip(waylandContext->display);
+
+  // If a seat was found, add a keyboard listener. This should trigger the
+  // sending of a `keymap` event that will allow us to get the data we want.
+  if (waylandContext->keyboard) {
+    wl_keyboard_add_listener(waylandContext->keyboard, &keyboard_listener,
+                             this);
+  } else {
+    CleanupWaylandContext(waylandContext);
+    goto x11;
+  }
+
+  // Wait for the keymap to be received.
+  //
+  // TODO: Timeout?
+  while (!waylandContext->keymap_received) {
+    if (wl_display_dispatch(waylandContext->display) < 0) {
+      CleanupWaylandContext(waylandContext);
+      goto x11;
+    }
+  }
+
+  // Once we've gotten this far, we have everything we need to inspect keyboard
+  // behavior. Now we'll set up polling on the event loop so we can find out
+  // when the keyboard layout changes.
+  SetupWaylandPolling();
+  return;
+
+#endif
+
+x11:
+  isWayland = false;
+  xDisplay = XOpenDisplay("");
+  CHECK_VOID(xDisplay, "Could not connect to X display", env);
+
+  xInputMethod = XOpenIM(xDisplay, 0, 0, 0);
+  if (!xInputMethod)
+    return;
+
+  XIMStyles *styles = 0;
+  if (XGetIMValues(xInputMethod, XNQueryInputStyle, &styles, NULL) || !styles) {
+    return;
+  }
+
+  XIMStyle bestMatchStyle = 0;
+  for (int i = 0; i < styles->count_styles; i++) {
+    XIMStyle thisStyle = styles->supported_styles[i];
+    if (thisStyle == (XIMPreeditNothing | XIMStatusNothing)) {
+      bestMatchStyle = thisStyle;
+      break;
+    }
+  }
+  XFree(styles);
+  if (!bestMatchStyle)
+    return;
+
+  Window window;
+  int revert_to;
+  XGetInputFocus(xDisplay, &window, &revert_to);
+  if (window != BadRequest) {
+    xInputContext =
+        XCreateIC(xInputMethod, XNInputStyle, bestMatchStyle, XNClientWindow,
+                  window, XNFocusWindow, window, NULL);
+  }
+}
+
+void KeyboardLayoutManager::PlatformTeardown() {
+#ifdef HAS_WAYLAND
+  CleanupWaylandPolling();
+  CleanupWaylandContext(waylandContext);
+#endif
+  callback.Reset();
+};
+
+Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(
+    const Napi::CallbackInfo &info) {
+  auto env = info.Env();
+  Napi::HandleScope scope(env);
+  Napi::Value result;
+
+  if (isWayland) {
+#ifdef HAS_WAYLAND
+    if (!waylandContext || !waylandContext->xkb_keymap ||
+        !waylandContext->xkb_state) {
+      return env.Null();
+    }
+
+    // Based on lots of experimentation with Gnome/Wayland, the layout at index
+    // 0 will always be the active layout. This may or may not be true for
+    // other Wayland server implementations, but we'll go with it for now —
+    // because if it isn't true, we'd be hard-pressed to discover that
+    // information any other way.
+    const char *layout_name =
+        xkb_keymap_layout_get_name(waylandContext->xkb_keymap, 0);
+
+#ifdef DEBUG
+    std::cout << "Current layout: " << layout_name << std::endl;
+#endif
+    result = Napi::String::New(env, layout_name);
+#endif
+  } else {
+    // X11
+    XkbRF_VarDefsRec vdr;
+    char *tmp = NULL;
+    if (XkbRF_GetNamesProp(xDisplay, &tmp, &vdr) && vdr.layout) {
+      XkbStateRec xkbState;
+      XkbGetState(xDisplay, XkbUseCoreKbd, &xkbState);
+      if (vdr.variant) {
+        result = Napi::String::New(
+            env, std::string(vdr.layout) + "," + std::string(vdr.variant) +
+                     " [" + std::to_string(xkbState.group) + "]");
+      } else {
+        result =
+            Napi::String::New(env, std::string(vdr.layout) + " [" +
+                                       std::to_string(xkbState.group) + "]");
+      }
+    } else {
+      result = env.Null();
+    }
+  }
+  return result;
+}
+
+
+Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLanguage(
+    const Napi::CallbackInfo &info) {
+  // No distinction between “language” and “layout” on Linux.
+  return GetCurrentKeyboardLayout(info);
+}
+
+Napi::Value KeyboardLayoutManager::GetInstalledKeyboardLanguages(
+    const Napi::CallbackInfo &info) {
+  auto env = info.Env();
+  Napi::HandleScope scope(env);
+  return env.Undefined();
+}
+
+struct KeycodeMapEntry {
+  uint xkbKeycode;
+  const char *dom3Code;
+};
+
+#define USB_KEYMAP_DECLARATION static const KeycodeMapEntry keyCodeMap[] =
+#define USB_KEYMAP(usb, evdev, xkb, win, mac, code, id)                        \
+  { xkb, code }
+
+#include "keycode_converter_data.inc"
+
+
+Napi::Value CharacterForNativeCode(Napi::Env env, XIC xInputContext,
+                                   XKeyEvent *keyEvent, uint xkbKeycode,
+                                   uint state) {
+  keyEvent->keycode = xkbKeycode;
+  keyEvent->state = state;
+
+  if (xInputContext) {
+    wchar_t characters[2];
+    char utf8[MB_CUR_MAX * 2 + 1];
+    int count =
+        XwcLookupString(xInputContext, keyEvent, characters, 2, NULL, NULL);
+    size_t len = wcstombs(utf8, characters, sizeof(utf8));
+    if (len == (size_t)-1) {
+      return env.Null();
+    }
+
+    if (count > 0 && !std::iswcntrl(characters[0])) {
+      return Napi::String::New(env, std::string(utf8, len));
+    } else {
+      return env.Null();
+    }
+  } else {
+    // Graceful fallback for systems where no window is open or no input
+    // context can be found.
+    char characters[2];
+    int count = XLookupString(keyEvent, characters, 2, NULL, NULL);
+    if (count > 0 && !std::iscntrl(characters[0])) {
+      return Napi::String::New(env, std::string(characters, count));
+    } else {
+      return env.Null();
+    }
+  }
+}
+
+
 Napi::Value
 KeyboardLayoutManager::GetCurrentKeymap(const Napi::CallbackInfo &info) {
   auto env = info.Env();
@@ -549,6 +637,7 @@ KeyboardLayoutManager::GetCurrentKeymap(const Napi::CallbackInfo &info) {
       Napi::String::New(env, "withAltGraphShift");
 
   if (isWayland) {
+#ifdef HAS_WAYLAND
     size_t keyCodeMapSize = sizeof(keyCodeMap) / sizeof(keyCodeMap[0]);
     for (size_t i = 0; i < keyCodeMapSize; i++) {
       const char *dom3Code = keyCodeMap[i].dom3Code;
@@ -576,6 +665,7 @@ KeyboardLayoutManager::GetCurrentKeymap(const Napi::CallbackInfo &info) {
         }
       }
     }
+#endif
   } else {
     // Clear cached keymap.
     XMappingEvent eventMap = {MappingNotify,   0, false, xDisplay, 0,
@@ -623,100 +713,3 @@ KeyboardLayoutManager::GetCurrentKeymap(const Napi::CallbackInfo &info) {
 
   return result;
 }
-
-void KeyboardLayoutManager::SetupWaylandPolling() {
-  if (!waylandContext || !waylandContext->display)
-    return;
-
-  int fd = wl_display_get_fd(waylandContext->display);
-
-  waylandPoll = new uv_poll_t;
-  waylandPoll->data = this;
-
-  uv_poll_init(uv_default_loop(), waylandPoll, fd);
-  uv_poll_start(waylandPoll, UV_READABLE, OnWaylandEvent);
-
-  // Unref the handles so they don't prevent process exit
-  uv_unref((uv_handle_t *)waylandPoll);
-
-  // // Create a check handle that runs in each iteration of the event loop
-  // exit_check = new uv_check_t;
-  // exit_check->data = this;
-  // uv_check_init(uv_default_loop(), exit_check);
-  //
-  // // Start the check handle
-  // uv_check_start(exit_check, [](uv_check_t* handle) {
-  //   KeyboardLayoutManager* manager =
-  //   static_cast<KeyboardLayoutManager*>(handle->data);
-  //
-  //   // If we're allowing exit and no other active handles exist except ours,
-  //   // then unref our handles to allow process to exit
-  //   if (manager && manager->allow_exit) {
-  //     // Unref the handles (keeps them active but doesn't block exit)
-  //     uv_unref((uv_handle_t*)manager->wayland_poll);
-  //     uv_unref((uv_handle_t*)manager->exit_check);
-  //
-  //     // Only do this once
-  //     manager->allow_exit = false;
-  //   }
-  // });
-  //
-}
-
-void KeyboardLayoutManager::OnWaylandEvent(uv_poll_t *handle, int status,
-                                           int events) {
-  std::cout << "OnWaylandEvent!" << std::endl;
-  KeyboardLayoutManager *instance =
-      static_cast<KeyboardLayoutManager *>(handle->data);
-  if (status < 0) {
-    // Error occurred
-    std::cout << "Error! " << status << std::endl;
-    return;
-  }
-
-  if (events & UV_READABLE) {
-    std::cout << "Dispatching pending events…" << std::endl;
-    while (wl_display_prepare_read(instance->waylandContext->display) != 0) {
-      wl_display_dispatch_pending(instance->waylandContext->display);
-    }
-    // Now read events (shouldn't block since we've been notified data is
-    // available)
-    if (wl_display_read_events(instance->waylandContext->display) < 0) {
-      std::cout << "ERROR Reading events…" << strerror(errno) << std::endl;
-      return;
-    }
-    // Dispatch the events we just read
-    std::cout << "Dispatching pending events…" << std::endl;
-    wl_display_dispatch_pending(instance->waylandContext->display);
-  }
-}
-
-void KeyboardLayoutManager::CleanupWaylandPolling() {
-  if (waylandPoll) {
-    uv_poll_stop(waylandPoll);
-    uv_close((uv_handle_t *)waylandPoll,
-             [](uv_handle_t *handle) { delete (uv_poll_t *)handle; });
-    waylandPoll = nullptr;
-  }
-}
-
-// // Runs on the main thread.
-// void KeyboardLayoutManager::ProcessCallback(
-//   Napi::Env env,
-//   Napi::Function callback
-// ) {
-//   auto that = env.GetInstanceData<KeyboardLayoutManager>();
-//   auto current = that->GetCurrentKeyboardLayout(env);
-//
-//   if (current.IsString()) {
-//     Napi::String str = current.As<Napi::String>();
-//     std::string value = str.Utf8Value();
-//     std::cout << "Sanity check: value is " << value << std::endl;
-//   } else {
-//     std::cout << "Sanity check: is NOT a string!";
-//   }
-//
-//   Napi::Object global = env.Global();
-//   callback.MakeCallback(global, {current.As<Napi::String>()});
-//   // callback.Call({current});
-// }

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -116,9 +116,19 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
   }
 
   // Try to find AltGr (ISO Level3 Shift) - this varies by layout
-  const char *alt_gr_names[] = {"ISO_Level3_Shift", "Mode_switch",
-                                "AltGr", "Alt"};
+  // const char *alt_gr_names[] = {"ISO_Level3_Shift", "Mode_switch",
+  //                               "AltGr", "Alt"};
 
+  const char *alt_gr_names[] = {
+      "ISO_Level3_Shift", // Most common for European layouts
+      "Mode_switch",      // Often used as an alias
+      "AltGr",            // Explicit name on some layouts
+      "Mod5",             // Often mapped to AltGr
+      "Mod3",             // Sometimes used for AltGr
+      "LevelThree",       // Another name used in some layouts
+      "Right Alt"         // Sometimes used explicitly
+  };
+  
   size_t alt_gr_length = sizeof(alt_gr_names) / sizeof(alt_gr_names[0]);
   for (size_t i = 0; i < alt_gr_length; i++) {
     xkb_mod_index_t idx =

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -128,13 +128,14 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
       "LevelThree",       // Another name used in some layouts
       "Right Alt"         // Sometimes used explicitly
   };
-  
+
   size_t alt_gr_length = sizeof(alt_gr_names) / sizeof(alt_gr_names[0]);
   for (size_t i = 0; i < alt_gr_length; i++) {
     xkb_mod_index_t idx =
         xkb_keymap_mod_get_index(ctx->xkb_keymap, alt_gr_names[i]);
     if (idx != XKB_MOD_INVALID) {
       std::cout << "Using AltGr name: " << alt_gr_names[i] << std::endl;
+      PrintModifierInfo(ctx, idx);
       ctx->alt_gr_mask = 1 << idx;
       break;
     }
@@ -173,9 +174,31 @@ static void keyboard_repeat_info(void *data, struct wl_keyboard *keyboard,
   // Not used
 }
 
+
 static const struct wl_keyboard_listener keyboard_listener = {
     keyboard_keymap, keyboard_enter,     keyboard_leave,
     keyboard_key,    keyboard_modifiers, keyboard_repeat_info};
+
+static void PrintModifierInfo(WaylandKeymapContext* ctx, xkb_mod_index_t mod_idx) {
+  const char mod_name = xkb_keymap_mod_get_name(ctx->xkb_keymap, mod_idx);
+  std::cout << "Mod name: " << mod_name << std::endl;
+
+  // List which keys are mapped to this modifier
+  for (xkb_keycode_t keycode = 8; keycode < 256; keycode++) {
+      // Skip if this keycode isn't valid
+      if (!xkb_keymap_key_get_name(ctx->xkb_keymap, keycode)) {
+          continue;
+      }
+
+      // Check if this key affects our modifier
+      if (xkb_keymap_mod_get_mask(ctx->xkb_keymap, mod_idx) &
+          xkb_keymap_key_get_mods_for_key(ctx->xkb_keymap, keycode)) {
+          const char* key_name = xkb_keymap_key_get_name(ctx->xkb_keymap, keycode);
+          std::cout << " Key " << key_name << " affects this modifier!" << std::endl;
+      }
+  }
+
+}
 
 static void FailOnWaylandSetup(Napi::Env env) {
   Napi::Error::New(env, "Failed to connect to Wayland display")
@@ -665,4 +688,28 @@ void KeyboardLayoutManager::CleanupWaylandPolling() {
 
 void KeyboardLayoutManager::ProcessCallbackWrapper() {
   ProcessCallback(_env, callback.Value().As<Napi::Function>());
+}
+
+
+//////
+
+void print_modifier_info(WaylandKeymapContext* ctx, xkb_mod_index_t mod_idx) {
+    const char* mod_name = xkb_keymap_mod_get_name(ctx->xkb_keymap, mod_idx);
+    fprintf(stderr, "Modifier %d: %s\n", mod_idx, mod_name ? mod_name : "unnamed");
+
+    // List which keys are mapped to this modifier
+    for (xkb_keycode_t keycode = 8; keycode < 256; keycode++) {
+        // Skip if this keycode isn't valid
+        if (!xkb_keymap_key_get_name(ctx->xkb_keymap, keycode)) {
+            continue;
+        }
+
+        // Check if this key affects our modifier
+        if (xkb_keymap_mod_get_mask(ctx->xkb_keymap, mod_idx) &
+            xkb_keymap_key_get_mods_for_key(ctx->xkb_keymap, keycode)) {
+            const char* key_name = xkb_keymap_key_get_name(ctx->xkb_keymap, keycode);
+            fprintf(stderr, "  Key %d (%s) affects this modifier\n",
+                   keycode, key_name ? key_name : "unnamed");
+        }
+    }
 }

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -332,6 +332,7 @@ void KeyboardLayoutManager::PlatformTeardown() {
 void KeyboardLayoutManager::HandleKeyboardLayoutChanged() {}
 
 const char* KeyboardLayoutManager::GetCurrentKeyboardLayout() {
+  const char* result;
   if (isWayland) {
     if (!waylandContext || !waylandContext->xkb_keymap ||
         !waylandContext->xkb_state) {

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -482,7 +482,7 @@ static char* get_key_char(WaylandKeymapContext *ctx, uint32_t keycode, xkb_mod_m
   // Create a copy of the XKB state so we can apply modifiers.
   struct xkb_state *temp_state = xkb_state_new(ctx->xkb_keymap);
   if (!temp_state) {
-    return NULL;
+    return strdup("error");
   }
 
   xkb_state_update_mask(temp_state, modifiers, 0, 0, 0, 0, 0);
@@ -490,7 +490,11 @@ static char* get_key_char(WaylandKeymapContext *ctx, uint32_t keycode, xkb_mod_m
   xkb_keysym_t keysym = xkb_state_key_get_one_sym(temp_state, xkb_keycode);
 
   // Allocate memory for the result.
-  char *result = new char[8]; // And remember to use delete[] instead of free
+  char *result = new char[32]; // And remember to use delete[] instead of free
+
+  // Try to get a UTF-8 representation
+  int len = xkb_keysym_to_utf8(keysym, buffer, 32);
+
   if (!result) {
     xkb_state_unref(temp_state);
     delete[] result;
@@ -500,12 +504,9 @@ static char* get_key_char(WaylandKeymapContext *ctx, uint32_t keycode, xkb_mod_m
   // Convert keysym to UTF-8.
   if (keysym == XKB_KEY_NoSymbol) {
     strcpy(result, "Dead");
-  } else {
-    int len = xkb_keysym_to_utf8(keysym, result, 0);
-    if (len <= 0) {
-      // If we couldn't get a UTF-8 character, fall back to the keysym’s name.
-      xkb_keysym_get_name(keysym, result, 0);
-    }
+  } else if (len <= 0) {
+    // If we couldn't get a UTF-8 character, fall back to the keysym’s name.
+    xkb_keysym_get_name(keysym, result, 32);
   }
 
   xkb_state_unref(temp_state);

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -335,18 +335,6 @@ void KeyboardLayoutManager::PlatformTeardown() {
 void KeyboardLayoutManager::HandleKeyboardLayoutChanged() {
 }
 
-static KeyboardStateWithShift(WaylandKeymapContext* ctx) {
-  // Create a temporary state
-  struct xkb_state* temp_state = xkb_state_new(ctx->xkb_keymap);
-  if (!temp_state) {
-    return 0; // Default to layout 0 on error
-  }
-
-  // Get the shift mask
-  xkb_mod_index_t shift_idx = xkb_keymap_mod_get_index(ctx->xkb_keymap, XKB_MOD_NAME_SHIFT);
-  xkb_mod_mask_t shift_mask = 1 << shift_idx;
-}
-
 Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::CallbackInfo& info) {
   auto env = info.Env();
   Napi::HandleScope scope(env);

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -221,6 +221,8 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
 
           result = Napi::String::New(env, layout_name);
 
+          std::cout << "Done with result!" << std::endl;
+
           // Add null checks before string construction
           // std::string layout_str = names.layout ? std::string(names.layout) : "unknown";
           // std::string variant_str = names.variant ? std::string(names.variant) : "";
@@ -232,7 +234,10 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
           // }
         }
       }
+
+      std::cout << "Unreffing…" << std::endl;
       xkb_keymap_unref(keymap);
+      std::cout << "…unreffed!" << std::endl;
       xkb_context_unref(context);
     } else {
       result = env.Null();

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -4,6 +4,8 @@
 #include <X11/XKBlib.h>
 #include <X11/Xutil.h>
 #include <X11/extensions/XKBrules.h>
+#include <sys/mman.h>
+#include <unistd.h>
 #include <cwctype>
 #include <cctype>
 #include <stdio.h>
@@ -47,7 +49,7 @@ static int detect_display_server() {
 static void registry_global(void *data, struct wl_registry *registry, uint32_t name, const char *interface, uint32_t version) {
   WaylandKeymapContext *ctx = (WaylandKeymapContext *)data;
   if (strcmp(interface, "wl_seat") == 0) {
-    ctx->seat = wl_registry_bind(registry, name, &wl_seat_interface, 1);
+    ctx->seat = (struct wl_seat*)wl_registry_bind(registry, name, &wl_seat_interface, 1);
     if (ctx->seat) {
       ctx->keyboard = wl_seat_get_keyboard(ctx->seat);
     }
@@ -84,7 +86,7 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
     return;
   }
 
-  ctx.xkb_keymap = xkb_keymap_new_from_string(ctx->xkb_context, keymap_string,
+  ctx->xkb_keymap = xkb_keymap_new_from_string(ctx->xkb_context, keymap_string,
                                               XKB_KEYMAP_FORMAT_TEXT_V1,
                                               XKB_KEYMAP_COMPILE_NO_FLAGS);
 
@@ -170,7 +172,7 @@ static CleanupWaylandContext(WaylandKeymapContext* ctx) {
       xkb_state_unref(ctx->xkb_state);
   if (ctx->xkb_keymap)
       xkb_keymap_unref(ctx->xkb_keymap);
-  if (ctx.xkb_context)
+  if (ctx->xkb_context)
       xkb_context_unref(ctx->xkb_context);
   if (ctx->keyboard)
       wl_keyboard_destroy(ctx->keyboard);

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -7,6 +7,7 @@
 #include <cwctype>
 #include <cctype>
 #include <stdio.h>
+#include <iostream>
 #include <locale.h>
 
 // Function to get current keyboard layout using xkbcommon

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -335,8 +335,6 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(Napi::Env env) {
   Napi::HandleScope scope(env);
   Napi::Value result;
 
-  return Napi::String::New(env, "test_layout_hardcoded");
-
   if (isWayland) {
     if (!waylandContext || !waylandContext->xkb_keymap ||
         !waylandContext->xkb_state) {

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -674,11 +674,17 @@ void KeyboardLayoutManager::OnWaylandEvent(uv_poll_t *handle, int status,
   }
 
   if (events & UV_READABLE) {
-    std::cout << "Reading events…" << std::endl;
-    // Read events from the display
-    wl_display_read_events(instance->waylandContext->display);
-
-    // Dispatch pending events
+    std::cout << "Dispatching pending events…" << std::endl;
+    while (wl_display_prepare_read(instance->waylandContext->display) != 0) {
+      wl_display_dispatch_pending(instance->waylandContext->display);
+    }
+    // Now read events (shouldn't block since we've been notified data is
+    // available)
+    if (wl_display_read_events(instance->waylandContext->display) < 0) {
+      std::cout << "ERROR Reading events…" << strerr(errno) << std::endl;
+      return;
+    }
+    // Dispatch the events we just read
     std::cout << "Dispatching pending events…" << std::endl;
     wl_display_dispatch_pending(instance->waylandContext->display);
   }

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -129,7 +129,7 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
   }
 
   ctx->keymap_received = true;
-  that->OnNotificationReceived();
+  that->ProcessCallbackWrapper();
 }
 
 static void keyboard_enter(void *data, struct wl_keyboard *keyboard,
@@ -194,7 +194,7 @@ static void CleanupWaylandContext(WaylandKeymapContext* ctx) {
 }
 
 void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
-  auto env = info.Env();
+  env = info.Env();
 
   // isWayland = detect_display_server() == 1;
   isWayland = true;
@@ -248,6 +248,8 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
         return;
       }
     }
+
+    SetupWaylandPolling();
     // We're good. We can exit.
     return;
   }
@@ -291,6 +293,7 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
 }
 
 void KeyboardLayoutManager::PlatformTeardown() {
+  CleanupWaylandPolling();
   CleanupWaylandContext(waylandContext);
   callback.Reset();
 };
@@ -573,4 +576,48 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeymap(const Napi::CallbackInfo& in
   }
 
   return result;
+}
+
+void KeyboardLayoutManager::SetupWaylandPolling() {
+  if (!waylandContext || !waylandContext->display) return;
+
+  int fd = wl_display_get_fd(waylandContext->display);
+
+  waylandPoll = new uv_poll_t;
+  waylandPoll->data = this;
+
+  uv_poll_init(uv_default_loop(), waylandPoll, fd);
+  uv_poll_start(waylandPoll, UV_READABLE, OnWaylandEvent);
+}
+
+void KeyboardLayoutManager::OnWaylandEvent(uv_poll_t *handle, int status,
+                                           int events) {
+  KeyboardLayoutManager *instance =
+      static_cast<KeyboardLayoutManager *>(handle->data);
+  if (status < 0) {
+    // Error occurred
+    return;
+  }
+
+  if (events & UV_READABLE) {
+    // Read events from the display
+    wl_display_read_events(instance->waylandContext->display);
+
+    // Dispatch pending events
+    wl_display_dispatch_pending(instance->waylandContext->display);
+  }
+}
+
+void KeyboardLayoutManager::CleanupWaylandPolling() {
+  if (waylandPoll) {
+    uv_poll_stop(waylandPoll);
+    uv_close((uv_handle_t *)waylandPoll,
+             [](uv_handle_t *handle) { delete (uv_poll_t *)handle; });
+    waylandPoll = nullptr;
+  }
+}
+
+
+void KeyboardLayoutManager::ProcessCallbackWrapper() {
+  ProcessCallback(env, callback);
 }

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -340,28 +340,36 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
   Napi::Value result;
 
   if (isWayland) {
-    if (!waylandContext || !waylandContext->xkb_keymap) {
+    if (!waylandContext || !waylandContext->xkb_keymap || !waylandContext->xkb_state) {
       return env.Null();
     }
 
-    // Get layout names - this is usually what you want for identification
-    char layout_id[256] = {0};
+    xkb_layout_index_t active_layout = xkb_state_get_layout(waylandContext->xkb_state, XKB_STATE_LAYOUT_EFFECTIVE);
 
-    // Get number of layouts
-    xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(waylandContext->xkb_keymap);
+    const char* active_layout_name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, group);
 
-    // Build a string with all layout names
-    for (xkb_layout_index_t i = 0; i < num_layouts; i++) {
-      const char* layout_name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, i);
-      if (layout_name) {
-        if (i > 0) {
-          strcat(layout_id, ",");
-        }
-        strcat(layout_id, layout_name);
-      }
+    if (active_layout_name) {
+      return Napi::String::New(env, active_layout_name);
     }
 
-    return Napi::String::New(env, layout_id);
+    // // Get layout names - this is usually what you want for identification
+    // char layout_id[256] = {0};
+    //
+    // // Get number of layouts
+    // xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(waylandContext->xkb_keymap);
+    //
+    // // Build a string with all layout names
+    // for (xkb_layout_index_t i = 0; i < num_layouts; i++) {
+    //   const char* layout_name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, i);
+    //   if (layout_name) {
+    //     if (i > 0) {
+    //       strcat(layout_id, ",");
+    //     }
+    //     strcat(layout_id, layout_name);
+    //   }
+    // }
+    //
+    // return Napi::String::New(env, layout_id);
   } else {
     // X11
     XkbRF_VarDefsRec vdr;

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -48,7 +48,10 @@ static int detect_display_server() {
 // =================
 
 static void registry_global(void *data, struct wl_registry *registry, uint32_t name, const char *interface, uint32_t version) {
-  WaylandKeymapContext *ctx = (static_cast<KeyboardLayoutManager *>(data))->waylandContext;
+  auto env = (static_cast<Napi::Env*>(data));
+  auto that = env.GetInstanceData<KeyboardLayoutManager>();
+  auto ctx = that->waylandContext;
+  // WaylandKeymapContext *ctx = (static_cast<KeyboardLayoutManager *>(data))->waylandContext;
   if (strcmp(interface, "wl_seat") == 0) {
     ctx->seat = (struct wl_seat*)wl_registry_bind(registry, name, &wl_seat_interface, 1);
     if (ctx->seat) {
@@ -72,8 +75,9 @@ static const struct wl_registry_listener registry_listener = {
 static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
                             uint32_t format, int32_t fd, uint32_t size) {
 
-  WaylandKeymapContext *ctx =
-      (static_cast<KeyboardLayoutManager *>(data))->waylandContext;
+  auto env = (static_cast<Napi::Env*>(data));
+  auto that = env.GetInstanceData<KeyboardLayoutManager>();
+  auto ctx = that->waylandContext;
 
   if (format != WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1) {
     close(fd);
@@ -123,7 +127,7 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
   }
 
   ctx->keymap_received = true;
-  (static_cast<KeyboardLayoutManager *>(data))->OnNotificationReceived();
+  that->OnNotificationReceived();
 }
 
 static void keyboard_enter(void *data, struct wl_keyboard *keyboard,
@@ -212,7 +216,7 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
 
     waylandContext->registry = wl_display_get_registry(waylandContext->display);
     std::cout << "Listener!" << std::endl;
-    wl_registry_add_listener(waylandContext->registry, &registry_listener, this);
+    wl_registry_add_listener(waylandContext->registry, &registry_listener, env);
 
     // Process registry events.
     wl_display_roundtrip(waylandContext->display);
@@ -224,7 +228,7 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
       wl_keyboard_add_listener(
         waylandContext->keyboard,
         &keyboard_listener,
-        this
+        env
       );
     } else {
       std::cout << "Oof 3!" << std::endl;

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -13,6 +13,11 @@
 #include <iostream>
 #include <locale.h>
 
+struct CallbackContext {
+  KeyboardLayoutManager* instance;
+  Napi::Env env;
+};
+
 // More robust detection combining multiple checks
 static int detect_display_server() {
   // Method 1: XDG_SESSION_TYPE - Can be most reliable when set correctly
@@ -48,10 +53,11 @@ static int detect_display_server() {
 // =================
 
 static void registry_global(void *data, struct wl_registry *registry, uint32_t name, const char *interface, uint32_t version) {
-  auto env = (static_cast<Napi::Env*>(data));
-  auto that = env->GetInstanceData<KeyboardLayoutManager>();
+  // auto env = (static_cast<Napi::Env*>(data));
+  // auto that = env->GetInstanceData<KeyboardLayoutManager>();
+  // auto ctx = that->waylandContext;
+  auto that = (static_cast<KeyboardLayoutManager *>(data));
   auto ctx = that->waylandContext;
-  // WaylandKeymapContext *ctx = (static_cast<KeyboardLayoutManager *>(data))->waylandContext;
   if (strcmp(interface, "wl_seat") == 0) {
     ctx->seat = (struct wl_seat*)wl_registry_bind(registry, name, &wl_seat_interface, 1);
     if (ctx->seat) {
@@ -75,8 +81,9 @@ static const struct wl_registry_listener registry_listener = {
 static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
                             uint32_t format, int32_t fd, uint32_t size) {
 
-  auto env = (static_cast<Napi::Env*>(data));
-  auto that = env->GetInstanceData<KeyboardLayoutManager>();
+  // auto env = (static_cast<Napi::Env*>(data));
+  // auto that = env->GetInstanceData<KeyboardLayoutManager>();
+  auto that = (static_cast<KeyboardLayoutManager *>(data));
   auto ctx = that->waylandContext;
 
   if (format != WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1) {
@@ -191,6 +198,11 @@ static void CleanupWaylandContext(WaylandKeymapContext* ctx) {
   }
 }
 
+struct CallbackContext {
+  KeyboardLayoutManager *instance;
+  Napi::Env env;
+};
+
 void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
   auto env = info.Env();
 
@@ -216,7 +228,7 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
 
     waylandContext->registry = wl_display_get_registry(waylandContext->display);
     std::cout << "Listener!" << std::endl;
-    wl_registry_add_listener(waylandContext->registry, &registry_listener, env);
+    wl_registry_add_listener(waylandContext->registry, &registry_listener, this);
 
     // Process registry events.
     wl_display_roundtrip(waylandContext->display);
@@ -228,7 +240,7 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
       wl_keyboard_add_listener(
         waylandContext->keyboard,
         &keyboard_listener,
-        env
+        this
       );
     } else {
       std::cout << "Oof 3!" << std::endl;

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -94,6 +94,8 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
     return;
   }
 
+  std::cout << "KEYMAP STRING: " << keymap_string << std::endl;
+
   ctx->xkb_keymap = xkb_keymap_new_from_string(ctx->xkb_context, keymap_string,
                                               XKB_KEYMAP_FORMAT_TEXT_V1,
                                               XKB_KEYMAP_COMPILE_NO_FLAGS);
@@ -612,39 +614,13 @@ Napi::Value CharacterForNativeCode(Napi::Env env, XIC xInputContext, XKeyEvent *
   }
 }
 
-xkb_state *copy_state_without_modifiers(WaylandKeymapContext *ctx) {
-  if (!ctx || !ctx->xkb_state || !ctx->xkb_keymap) {
-    return nullptr;
-  }
-
-  // Create a new state from the keymap
-  xkb_state *new_state = xkb_state_new(ctx->xkb_keymap);
-  if (!new_state) {
-    return nullptr;
-  }
-
-  // Get the current group/layout index
-  xkb_layout_index_t group = xkb_state_serialize_layout(ctx->xkb_state);
-
-  // Update the new state with:
-  // - No depressed modifiers (0)
-  // - No latched modifiers (0)
-  // - No locked modifiers (0)
-  // - Current layout/group index
-  // - No latched layout (0)
-  // - No locked layout (0)
-  xkb_state_update_mask(new_state, 0, 0, 0, group, 0, 0);
-
-  return new_state;
-}
-
 static char* get_key_char(WaylandKeymapContext *ctx, uint32_t keycode, xkb_mod_mask_t modifiers) {
   // At first I thought we needed to offset this by 8, but it already seems
   // correct as-is.
   xkb_keycode_t xkb_keycode = keycode;
 
   // Create a copy of the XKB state so we can apply modifiers.
-  struct xkb_state *temp_state = copy_state_without_modifiers(ctx);
+  struct xkb_state *temp_state = xkb_state_new(ctx->xkb_keymap);
   if (!temp_state) {
     return strdup("error");
   }

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -12,6 +12,7 @@
 #include <unistd.h>
 #include <optional>
 
+#ifdef HAS_WAYLAND
 // Enumerates the various modifiers on this keyboard and tests which one brings
 // us to Level 3. This correlates to what we expect from the AltGr key.
 static std::optional<size_t> IndexOfLevel3Modifier(WaylandKeymapContext* ctx) {
@@ -249,54 +250,6 @@ static void CleanupWaylandContext(WaylandKeymapContext *ctx) {
   }
 }
 
-// Napi::Value CharacterForNativeCodeWayland(Napi::Env env,
-//                                           xkb_context *xkbContext,
-//                                           xkb_keymap *xkbKeymap,
-//                                           xkb_state *xkbState,
-//                                           uint32_t xkbKeycode, uint32_t state) {
-//   if (!xkbContext || !xkbKeymap || !xkbState) {
-//     return env.Null();
-//   }
-//
-//   xkb_state_update_mask(xkbState, 0, 0, 0, 0, 0, 0);
-//
-//   xkb_mod_mask_t mod_mask = 0;
-//
-//   // Map standard modifiers
-//   struct {
-//     uint32_t x11_mask;
-//     const char *xkb_name;
-//   } modifiers[] = {{ShiftMask, XKB_MOD_NAME_SHIFT},
-//                    {LockMask, XKB_MOD_NAME_CAPS},
-//                    {ControlMask, XKB_MOD_NAME_CTRL},
-//                    {Mod1Mask, XKB_MOD_NAME_ALT},
-//                    // Mod5Mask is often ISO_Level3_Shift (AltGr)
-//                    {Mod5Mask, "iso_level3_shift"}};
-//
-//   for (const auto &mod : modifiers) {
-//     if (state & mod.x11_mask) {
-//       xkb_mod_index_t mod_idx =
-//           xkb_keymap_mod_get_index(xkbKeymap, mod.xkb_name);
-//       if (mod_idx != XKB_MOD_INVALID) {
-//         mod_mask |= (1 << mod_idx);
-//       }
-//     }
-//   }
-//
-//   xkb_state_update_mask(xkbState, mod_mask, 0, 0, 0, 0, 0);
-//
-//   xkb_keysym_t keysym = xkb_state_key_get_one_sym(xkbState, xkbKeycode);
-//
-//   char buffer[8] = {0};
-//   int length = xkb_keysym_to_utf8(keysym, buffer, sizeof(buffer));
-//
-//   if (length > 0 && !std::iscntrl(buffer[0])) {
-//     return Napi::String::New(env, std::string(buffer, length));
-//   } else {
-//     return env.Null();
-//   }
-// }
-
 // Given a Wayland context, a keycode, and a modifier mask, return the
 // character that would be produced by that keycode.
 static char *get_key_char(WaylandKeymapContext *ctx, uint32_t keycode,
@@ -416,6 +369,7 @@ void KeyboardLayoutManager::CleanupWaylandPolling() {
   }
 }
 
+#endif
 
 void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo &info) {
   auto env = info.Env();

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -590,8 +590,38 @@ void KeyboardLayoutManager::SetupWaylandPolling() {
   waylandPoll = new uv_poll_t;
   waylandPoll->data = this;
 
-  uv_poll_init(uv_default_loop(), waylandPoll, fd);
-  uv_poll_start(waylandPoll, UV_READABLE, OnWaylandEvent);
+  // uv_poll_init(uv_default_loop(), waylandPoll, fd);
+  // uv_poll_start(waylandPoll, UV_READABLE, OnWaylandEvent);
+
+  // Unref the handles so they don't prevent process exit
+  // uv_unref((uv_handle_t*)wayland_poll);
+
+  // // Create a check handle that runs in each iteration of the event loop
+  // exit_check = new uv_check_t;
+  // exit_check->data = this;
+  // uv_check_init(uv_default_loop(), exit_check);
+  //
+  // // Start the check handle
+  // uv_check_start(exit_check, [](uv_check_t* handle) {
+  //   KeyboardLayoutManager* manager = static_cast<KeyboardLayoutManager*>(handle->data);
+  //
+  //   // If we're allowing exit and no other active handles exist except ours,
+  //   // then unref our handles to allow process to exit
+  //   if (manager && manager->allow_exit) {
+  //     // Unref the handles (keeps them active but doesn't block exit)
+  //     uv_unref((uv_handle_t*)manager->wayland_poll);
+  //     uv_unref((uv_handle_t*)manager->exit_check);
+  //
+  //     // Only do this once
+  //     manager->allow_exit = false;
+  //   }
+  // });
+  //
+}
+
+// Call this when the JavaScript side indicates it's okay to exit
+void KeyboardLayoutManager::AllowExit() {
+  allow_exit = true;
 }
 
 void KeyboardLayoutManager::OnWaylandEvent(uv_poll_t *handle, int status,
@@ -614,9 +644,9 @@ void KeyboardLayoutManager::OnWaylandEvent(uv_poll_t *handle, int status,
 
 void KeyboardLayoutManager::CleanupWaylandPolling() {
   if (waylandPoll) {
-    uv_poll_stop(waylandPoll);
-    uv_close((uv_handle_t *)waylandPoll,
-             [](uv_handle_t *handle) { delete (uv_poll_t *)handle; });
+    // uv_poll_stop(waylandPoll);
+    // uv_close((uv_handle_t *)waylandPoll,
+    //          [](uv_handle_t *handle) { delete (uv_poll_t *)handle; });
     waylandPoll = nullptr;
   }
 }

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -43,8 +43,8 @@ static int detect_display_server() {
   return -1;
 }
 
-static IndexOfLevel3Modifier(WaylandKeymapContext* ctx) {
-  struct xkb_state *state = xkb_state_new(ctx->keymap);
+static size_t IndexOfLevel3Modifier(WaylandKeymapContext* ctx) {
+  struct xkb_state *state = xkb_state_new(ctx->xkb_keymap);
   for (xkb_mod_index_t mod = 0; mod < xkb_keymap_num_mods(ctx->xkb_keymap); mod++) {
     xkb_mod_mask_t mask = 1 << mod;
     const char *mod_name = xkb_keymap_mod_get_name(ctx->xkb_keymap, mod);
@@ -164,7 +164,7 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
   size_t alt_gr_index = IndexOfLevel3Modifier(ctx);
 
   if (alt_gr_index > 0) {
-    ctx_alt_gr_mask = 1 << alt_gr_index;
+    ctx->alt_gr_mask = 1 << alt_gr_index;
   } else {
     const char *alt_gr_names[] = {
         "ISO_Level3_Shift", // Most common for European layouts

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -477,7 +477,7 @@ Napi::Value CharacterForNativeCode(Napi::Env env, XIC xInputContext, XKeyEvent *
 
 static char* get_key_char(WaylandKeymapContext *ctx, uint32_t keycode, xkb_mod_mask_t modifiers) {
   // XKB keycodes are offset by 8 from evdev keycodes.
-  xkb_keycode_t xkb_keycode = keycode + 8;
+  xkb_keycode_t xkb_keycode = keycode;
 
   // Create a copy of the XKB state so we can apply modifiers.
   struct xkb_state *temp_state = xkb_state_new(ctx->xkb_keymap);

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -168,7 +168,7 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
   }
 
   ctx->keymap_received = true;
-  that->ProcessCallbackWrapper();
+  that->OnNotificationReceived();
 }
 
 static void keyboard_enter(void *data, struct wl_keyboard *keyboard,

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -249,53 +249,53 @@ static void CleanupWaylandContext(WaylandKeymapContext *ctx) {
   }
 }
 
-Napi::Value CharacterForNativeCodeWayland(Napi::Env env,
-                                          xkb_context *xkbContext,
-                                          xkb_keymap *xkbKeymap,
-                                          xkb_state *xkbState,
-                                          uint32_t xkbKeycode, uint32_t state) {
-  if (!xkbContext || !xkbKeymap || !xkbState) {
-    return env.Null();
-  }
-
-  xkb_state_update_mask(xkbState, 0, 0, 0, 0, 0, 0);
-
-  xkb_mod_mask_t mod_mask = 0;
-
-  // Map standard modifiers
-  struct {
-    uint32_t x11_mask;
-    const char *xkb_name;
-  } modifiers[] = {{ShiftMask, XKB_MOD_NAME_SHIFT},
-                   {LockMask, XKB_MOD_NAME_CAPS},
-                   {ControlMask, XKB_MOD_NAME_CTRL},
-                   {Mod1Mask, XKB_MOD_NAME_ALT},
-                   // Mod5Mask is often ISO_Level3_Shift (AltGr)
-                   {Mod5Mask, "iso_level3_shift"}};
-
-  for (const auto &mod : modifiers) {
-    if (state & mod.x11_mask) {
-      xkb_mod_index_t mod_idx =
-          xkb_keymap_mod_get_index(xkbKeymap, mod.xkb_name);
-      if (mod_idx != XKB_MOD_INVALID) {
-        mod_mask |= (1 << mod_idx);
-      }
-    }
-  }
-
-  xkb_state_update_mask(xkbState, mod_mask, 0, 0, 0, 0, 0);
-
-  xkb_keysym_t keysym = xkb_state_key_get_one_sym(xkbState, xkbKeycode);
-
-  char buffer[8] = {0};
-  int length = xkb_keysym_to_utf8(keysym, buffer, sizeof(buffer));
-
-  if (length > 0 && !std::iscntrl(buffer[0])) {
-    return Napi::String::New(env, std::string(buffer, length));
-  } else {
-    return env.Null();
-  }
-}
+// Napi::Value CharacterForNativeCodeWayland(Napi::Env env,
+//                                           xkb_context *xkbContext,
+//                                           xkb_keymap *xkbKeymap,
+//                                           xkb_state *xkbState,
+//                                           uint32_t xkbKeycode, uint32_t state) {
+//   if (!xkbContext || !xkbKeymap || !xkbState) {
+//     return env.Null();
+//   }
+//
+//   xkb_state_update_mask(xkbState, 0, 0, 0, 0, 0, 0);
+//
+//   xkb_mod_mask_t mod_mask = 0;
+//
+//   // Map standard modifiers
+//   struct {
+//     uint32_t x11_mask;
+//     const char *xkb_name;
+//   } modifiers[] = {{ShiftMask, XKB_MOD_NAME_SHIFT},
+//                    {LockMask, XKB_MOD_NAME_CAPS},
+//                    {ControlMask, XKB_MOD_NAME_CTRL},
+//                    {Mod1Mask, XKB_MOD_NAME_ALT},
+//                    // Mod5Mask is often ISO_Level3_Shift (AltGr)
+//                    {Mod5Mask, "iso_level3_shift"}};
+//
+//   for (const auto &mod : modifiers) {
+//     if (state & mod.x11_mask) {
+//       xkb_mod_index_t mod_idx =
+//           xkb_keymap_mod_get_index(xkbKeymap, mod.xkb_name);
+//       if (mod_idx != XKB_MOD_INVALID) {
+//         mod_mask |= (1 << mod_idx);
+//       }
+//     }
+//   }
+//
+//   xkb_state_update_mask(xkbState, mod_mask, 0, 0, 0, 0, 0);
+//
+//   xkb_keysym_t keysym = xkb_state_key_get_one_sym(xkbState, xkbKeycode);
+//
+//   char buffer[8] = {0};
+//   int length = xkb_keysym_to_utf8(keysym, buffer, sizeof(buffer));
+//
+//   if (length > 0 && !std::iscntrl(buffer[0])) {
+//     return Napi::String::New(env, std::string(buffer, length));
+//   } else {
+//     return env.Null();
+//   }
+// }
 
 // Given a Wayland context, a keycode, and a modifier mask, return the
 // character that would be produced by that keycode.
@@ -318,7 +318,7 @@ static char *get_key_char(WaylandKeymapContext *ctx, uint32_t keycode,
   // Allocate memory for the result.
   char *result = new char[32];
 
-  // Try to get a UTF-8 representation
+  // Try to get a UTF-8 representation.
   int len = xkb_keysym_to_utf8(keysym, result, 32);
 
   if (!result) {
@@ -371,28 +371,38 @@ void KeyboardLayoutManager::SetupWaylandPolling() {
 
 void KeyboardLayoutManager::OnWaylandEvent(uv_poll_t *handle, int status,
                                            int events) {
+#ifdef DEBUG
   std::cout << "OnWaylandEvent!" << std::endl;
+#endif
   KeyboardLayoutManager *instance =
       static_cast<KeyboardLayoutManager *>(handle->data);
   if (status < 0) {
     // Error occurred
+#ifdef DEBUG
     std::cout << "Error! " << status << std::endl;
+#endif
     return;
   }
 
   if (events & UV_READABLE) {
+#ifdef DEBUG
     std::cout << "Dispatching pending events…" << std::endl;
+#endif
     while (wl_display_prepare_read(instance->waylandContext->display) != 0) {
       wl_display_dispatch_pending(instance->waylandContext->display);
     }
     // Now read events (shouldn't block since we've been notified data is
     // available)
     if (wl_display_read_events(instance->waylandContext->display) < 0) {
-      std::cout << "ERROR Reading events…" << strerror(errno) << std::endl;
+#ifdef DEBUG
+    std::cout << "ERROR Reading events…" << strerror(errno) << std::endl;
+#endif
       return;
     }
     // Dispatch the events we just read
+#ifdef DEBUG
     std::cout << "Dispatching pending events…" << std::endl;
+#endif
     wl_display_dispatch_pending(instance->waylandContext->display);
   }
 }

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -48,7 +48,7 @@ static int detect_display_server() {
 // =================
 
 static void registry_global(void *data, struct wl_registry *registry, uint32_t name, const char *interface, uint32_t version) {
-  WaylandKeymapContext *ctx = (static_cast<KeyboardLayoutManager *>(manager))->waylandContext;
+  WaylandKeymapContext *ctx = (static_cast<KeyboardLayoutManager *>(data))->waylandContext;
   if (strcmp(interface, "wl_seat") == 0) {
     ctx->seat = (struct wl_seat*)wl_registry_bind(registry, name, &wl_seat_interface, 1);
     if (ctx->seat) {
@@ -73,7 +73,7 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
                             uint32_t format, int32_t fd, uint32_t size) {
 
   WaylandKeymapContext *ctx =
-      (static_cast<KeyboardLayoutManager *>(manager))->waylandContext;
+      (static_cast<KeyboardLayoutManager *>(data))->waylandContext;
 
   if (format != WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1) {
     close(fd);
@@ -123,7 +123,7 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
   }
 
   ctx->keymap_received = true;
-  (static_cast<KeyboardLayoutManager *>(manager))->OnNotificationReceived();
+  (static_cast<KeyboardLayoutManager *>(data))->OnNotificationReceived();
 }
 
 static void keyboard_enter(void *data, struct wl_keyboard *keyboard,

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -344,7 +344,6 @@ const char* KeyboardLayoutManager::GetCurrentKeyboardLayout() {
         xkb_keymap_layout_get_name(waylandContext->xkb_keymap, 0);
 
     std::cout << "Current layout: " << layout_name << std::endl;
-    currentLayout = layout_name;
     result = layout_name;
     // result = Napi::String::New(env, layout_name);
   } else {
@@ -375,11 +374,54 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(Napi::Env env) {
   Napi::HandleScope scope(env);
 
   const char* rawResult = GetCurrentKeyboardLayout();
-  if (rawResult == "") {
+  if (strcmp(rawResult, "") == 0) {
     return env.Null();
   }
   return Napi::String::New(env, rawResult);
 }
+
+void KeyboardLayoutManager::ProcessCallback(
+  Napi::Env env,
+  Napi::Function callback
+) {
+  auto that = env.GetInstanceData<KeyboardLayoutManager>();
+  const char* rawResult = that->GetCurrentKeyboardLayout();
+
+  Napi::Value result;
+  if (strcmp(rawResult, "") == 0) {
+    result = env.Null();
+  } else {
+    result = Napi::String::New(env, rawResult);
+  }
+  // that->GetCurrentKeyboardLayout(env);
+
+  // if (current.IsString()) {
+  //   Napi::String str = current.As<Napi::String>();
+  //   std::string value = str.Utf8Value();
+  //   std::cout << "Sanity check: value is " << value << std::endl;
+  // } else {
+  //   std::cout << "Sanity check: is NOT a string!";
+  // }
+
+  callback.Call({ result });
+
+  // Create arguments array with the layout
+  // std::vector<napi_value> args = { str };
+  //
+  // // Call JS callback with explicit this and args
+  // napi_value global;
+  // napi_get_global(env, &global);
+  //
+  // napi_value result;
+  // napi_call_function(env, global, callback, 1, args.data(), &result);
+  //
+  // std::cout << "Weird Result: " << result << std::endl;
+
+  // Napi::Object global = env.Global();
+  // callback.MakeCallback(global, {current.As<Napi::String>()});
+  // callback.Call({current});
+}
+
 
 Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(
     const Napi::CallbackInfo &info) {

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -331,12 +331,12 @@ void KeyboardLayoutManager::PlatformTeardown() {
 
 void KeyboardLayoutManager::HandleKeyboardLayoutChanged() {}
 
-const char* KeyboardLayoutManager::GetCurrentKeyboardLayout() {
-  const char* result;
+std::string KeyboardLayoutManager::GetCurrentKeyboardLayout() {
+  std::string result;
   if (isWayland) {
     if (!waylandContext || !waylandContext->xkb_keymap ||
         !waylandContext->xkb_state) {
-      return "";
+      return std::string("");
     }
 
     // Based on lots of experimentation with Gnome/Wayland, the layout at index
@@ -345,7 +345,7 @@ const char* KeyboardLayoutManager::GetCurrentKeyboardLayout() {
         xkb_keymap_layout_get_name(waylandContext->xkb_keymap, 0);
 
     std::cout << "Current layout: " << layout_name << std::endl;
-    result = layout_name;
+    result = std::string(layout_name);
     // result = Napi::String::New(env, layout_name);
   } else {
     // X11
@@ -365,7 +365,7 @@ const char* KeyboardLayoutManager::GetCurrentKeyboardLayout() {
             // Napi::String::New(env, );
       }
     } else {
-      result = "";
+      result = std::string("");
     }
   }
   return result;
@@ -386,13 +386,13 @@ void KeyboardLayoutManager::ProcessCallback(
   Napi::Function callback
 ) {
   auto that = env.GetInstanceData<KeyboardLayoutManager>();
-  const char* rawResult = that->GetCurrentKeyboardLayout();
+  std::string rawResult = that->GetCurrentKeyboardLayout();
 
   Napi::Value result;
-  if (strcmp(rawResult, "") == 0) {
+  if (rawResult == "") {
     result = env.Null();
   } else {
-    result = Napi::String::New(env, rawResult);
+    result = Napi::String::New(env, rawResult.c_str());
   }
   // that->GetCurrentKeyboardLayout(env);
 

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -334,12 +334,14 @@ void KeyboardLayoutManager::PlatformTeardown() {
 
 void KeyboardLayoutManager::HandleKeyboardLayoutChanged() {}
 
-std::string KeyboardLayoutManager::GetCurrentKeyboardLayout() {
-  std::string result;
+Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(Napi::Env env) {
+  Napi::HandleScope scope(env);
+  Napi::Value result;
+
   if (isWayland) {
     if (!waylandContext || !waylandContext->xkb_keymap ||
         !waylandContext->xkb_state) {
-      return std::string("");
+      return env.Null();
     }
 
     // Based on lots of experimentation with Gnome/Wayland, the layout at index
@@ -348,8 +350,7 @@ std::string KeyboardLayoutManager::GetCurrentKeyboardLayout() {
         xkb_keymap_layout_get_name(waylandContext->xkb_keymap, 0);
 
     std::cout << "Current layout: " << layout_name << std::endl;
-    result = std::string(layout_name);
-    // result = Napi::String::New(env, layout_name);
+    result = Napi::String::New(env, layout_name);
   } else {
     // X11
     XkbRF_VarDefsRec vdr;
@@ -358,74 +359,20 @@ std::string KeyboardLayoutManager::GetCurrentKeyboardLayout() {
       XkbStateRec xkbState;
       XkbGetState(xDisplay, XkbUseCoreKbd, &xkbState);
       if (vdr.variant) {
-        result = (std::string(vdr.layout) + "," + std::string(vdr.variant) +
-                 " [" + std::to_string(xkbState.group) + "]");
-        // result = Napi::String::New(
-        //     env, );
+        result = Napi::String::New(
+            env, std::string(vdr.layout) + "," + std::string(vdr.variant) +
+                     " [" + std::to_string(xkbState.group) + "]");
       } else {
-        result = std::string(vdr.layout) + " [" +
-                                   std::to_string(xkbState.group) + "]";
-            // Napi::String::New(env, );
+        result =
+            Napi::String::New(env, std::string(vdr.layout) + " [" +
+                                       std::to_string(xkbState.group) + "]");
       }
     } else {
-      result = std::string("");
+      result = env.Null();
     }
   }
   return result;
 }
-
-Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(Napi::Env env) {
-  Napi::HandleScope scope(env);
-
-  std::string rawResult = GetCurrentKeyboardLayout();
-  if (rawResult == "") {
-    return env.Null();
-  }
-  return Napi::String::New(env, rawResult.c_str());
-}
-
-void KeyboardLayoutManager::ProcessCallback(
-  Napi::Env env,
-  Napi::Function callback
-) {
-  auto that = env.GetInstanceData<KeyboardLayoutManager>();
-  std::string rawResult = that->GetCurrentKeyboardLayout();
-
-  Napi::Value result;
-  if (rawResult == "") {
-    result = env.Null();
-  } else {
-    result = Napi::String::New(env, rawResult.c_str());
-  }
-  // that->GetCurrentKeyboardLayout(env);
-
-  // if (current.IsString()) {
-  //   Napi::String str = current.As<Napi::String>();
-  //   std::string value = str.Utf8Value();
-  //   std::cout << "Sanity check: value is " << value << std::endl;
-  // } else {
-  //   std::cout << "Sanity check: is NOT a string!";
-  // }
-
-  callback.Call({ result });
-
-  // Create arguments array with the layout
-  // std::vector<napi_value> args = { str };
-  //
-  // // Call JS callback with explicit this and args
-  // napi_value global;
-  // napi_get_global(env, &global);
-  //
-  // napi_value result;
-  // napi_call_function(env, global, callback, 1, args.data(), &result);
-  //
-  // std::cout << "Weird Result: " << result << std::endl;
-
-  // Napi::Object global = env.Global();
-  // callback.MakeCallback(global, {current.As<Napi::String>()});
-  // callback.Call({current});
-}
-
 
 Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(
     const Napi::CallbackInfo &info) {

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -80,7 +80,7 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
     return;
   }
 
-  char *keymap_string = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
+  char *keymap_string = (char *)mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
   if (keymap_string == MAP_FAILED) {
     close(fd);
     return;
@@ -516,22 +516,26 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeymap(const Napi::CallbackInfo& in
     for (size_t i = 0; i < keyCodeMapSize; i++) {
       const char *dom3Code = keyCodeMap[i].dom3Code;
       uint xkbKeycode = keyCodeMap[i].xkbKeycode;
-    }
-    if (dom3Code && xkbKeycode > 0x0000) {
-      Napi::String dom3CodeKey = Napi::String::New(env, dom3Code);
-      Napi::Value unmodified = WaylandCharacterForCode(env, xkbKeycode, 0);
-      Napi::Value withShift = WaylandCharacterForCode(env, xkbKeycode, ctx->shift_mask);
-      Napi::Value withAltGraph = WaylandCharacterForCode(env, waylandContext, xkbKeycode, ctx->alt_gr_mask);
-      Napi::Value withAltGraphShift = WaylandCharacterForCode(env, waylandContext, xkbKeycode, ctx->shift_mask | ctx->alt_gr_mask);
+      if (dom3Code && xkbKeycode > 0x0000) {
+        Napi::String dom3CodeKey = Napi::String::New(env, dom3Code);
+        Napi::Value unmodified = WaylandCharacterForCode(env, waylandContext, xkbKeycode, 0);
+        Napi::Value withShift =
+            WaylandCharacterForCode(env, waylandContext, xkbKeycode, waylandContext->shift_mask);
+        Napi::Value withAltGraph = WaylandCharacterForCode(
+            env, waylandContext, xkbKeycode, waylandContext->alt_gr_mask);
+        Napi::Value withAltGraphShift = WaylandCharacterForCode(
+            env, waylandContext, xkbKeycode,
+            waylandContext->shift_mask | waylandContext->alt_gr_mask);
 
-      if (unmodified.IsString() || withShift.IsString() ||
-          withAltGraph.IsString() || withAltGraphShift.IsString()) {
-        Napi::Object entry = Napi::Object::New(env);
-        (entry).Set(unmodifiedKey, unmodified);
-        (entry).Set(withShiftKey, withShift);
-        (entry).Set(withAltGraphKey, withAltGraph);
-        (entry).Set(withAltGraphShiftKey, withAltGraphShift);
-        (result).Set(dom3CodeKey, entry);
+        if (unmodified.IsString() || withShift.IsString() ||
+            withAltGraph.IsString() || withAltGraphShift.IsString()) {
+          Napi::Object entry = Napi::Object::New(env);
+          (entry).Set(unmodifiedKey, unmodified);
+          (entry).Set(withShiftKey, withShift);
+          (entry).Set(withAltGraphKey, withAltGraph);
+          (entry).Set(withAltGraphShiftKey, withAltGraphShift);
+          (result).Set(dom3CodeKey, entry);
+        }
       }
     }
   } else {

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -187,7 +187,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
       const char *env_variant = getenv("XKB_DEFAULT_VARIANT");
       const char *env_options = getenv("XKB_DEFAULT_OPTIONS");
 
-      std::cout << "Layout from env?" << env_layout << std::endl;
+      // std::cout << "Layout from env?" << env_layout << std::endl;
 
       struct xkb_rule_names names = {
         .rules = env_rules,

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -5,14 +5,17 @@
 #include <X11/extensions/XKBrules.h>
 #include <cctype>
 #include <cwctype>
-#include <iostream>
 #include <locale.h>
 #include <stdio.h>
 #include <sys/mman.h>
 #include <unistd.h>
-#include <optional>
+
+#ifdef DEBUG
+#include <iostream>
+#endif
 
 #ifdef HAS_WAYLAND
+#include <optional>
 // Enumerates the various modifiers on this keyboard and tests which one brings
 // us to Level 3. This correlates to what we expect from the AltGr key.
 static std::optional<size_t> IndexOfLevel3Modifier(WaylandKeymapContext* ctx) {

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -285,34 +285,8 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
 }
 
 void KeyboardLayoutManager::PlatformTeardown() {
-  if (xkbState) {
-    xkb_state_unref(xkbState);
-  }
-
-  if (xkbKeymap) {
-    xkb_keymap_unref(xkbKeymap);
-  }
-
-  if (xkbContext) {
-    xkb_context_unref(xkbContext);
-  }
-
-  std::cout << "Teardown!" << std::endl;
-  if (xInputContext) {
-    XDestroyIC(xInputContext);
-  }
-  std::cout << "Teardown 1" << std::endl;
-
-  if (xInputMethod) {
-    XCloseIM(xInputMethod);
-  }
-
-  std::cout << "Teardown 2" << std::endl;
-  if (xDisplay) {
-    XCloseDisplay(xDisplay);
-  }
+  CleanupWaylandContext(waylandContext);
   callback.Reset();
-  std::cout << "Teardown 3" << std::endl;
 };
 
 void KeyboardLayoutManager::HandleKeyboardLayoutChanged() {

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -335,6 +335,8 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(Napi::Env env) {
   Napi::HandleScope scope(env);
   Napi::Value result;
 
+  return Napi::String::New(env, "test_layout_hardcoded");
+
   if (isWayland) {
     if (!waylandContext || !waylandContext->xkb_keymap ||
         !waylandContext->xkb_state) {

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -1,17 +1,16 @@
 #include "keyboard-layout-manager.h"
 
-#include <xkbcommon/xkbcommon.h>
 #include <X11/XKBlib.h>
 #include <X11/Xutil.h>
 #include <X11/extensions/XKBrules.h>
-#include <sys/mman.h>
-#include <unistd.h>
-#include <cwctype>
 #include <cctype>
-#include <stdio.h>
-#include <sstream>
+#include <cwctype>
 #include <iostream>
 #include <locale.h>
+#include <stdio.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <xkbcommon/xkbcommon.h>
 
 // More robust detection combining multiple checks
 static int detect_display_server() {
@@ -43,18 +42,20 @@ static int detect_display_server() {
   return -1;
 }
 
-
 // REGISTRY LISTENER
 // =================
 
-static void registry_global(void *data, struct wl_registry *registry, uint32_t name, const char *interface, uint32_t version) {
+static void registry_global(void *data, struct wl_registry *registry,
+                            uint32_t name, const char *interface,
+                            uint32_t version) {
   // auto env = (static_cast<Napi::Env*>(data));
   // auto that = env->GetInstanceData<KeyboardLayoutManager>();
   // auto ctx = that->waylandContext;
   auto that = (static_cast<KeyboardLayoutManager *>(data));
   auto ctx = that->waylandContext;
   if (strcmp(interface, "wl_seat") == 0) {
-    ctx->seat = (struct wl_seat*)wl_registry_bind(registry, name, &wl_seat_interface, 1);
+    ctx->seat = (struct wl_seat *)wl_registry_bind(registry, name,
+                                                   &wl_seat_interface, 1);
     if (ctx->seat) {
       ctx->keyboard = wl_seat_get_keyboard(ctx->seat);
     }
@@ -93,8 +94,8 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
   }
 
   ctx->xkb_keymap = xkb_keymap_new_from_string(ctx->xkb_context, keymap_string,
-                                              XKB_KEYMAP_FORMAT_TEXT_V1,
-                                              XKB_KEYMAP_COMPILE_NO_FLAGS);
+                                               XKB_KEYMAP_FORMAT_TEXT_V1,
+                                               XKB_KEYMAP_COMPILE_NO_FLAGS);
 
   munmap(keymap_string, size);
   close(fd);
@@ -123,6 +124,7 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
     xkb_mod_index_t idx =
         xkb_keymap_mod_get_index(ctx->xkb_keymap, alt_gr_names[i]);
     if (idx != XKB_MOD_INVALID) {
+      std::cout << "Using AltGr name: " << alt_gr_names[i] << std::endl;
       ctx->alt_gr_mask = 1 << idx;
       break;
     }
@@ -162,38 +164,34 @@ static void keyboard_repeat_info(void *data, struct wl_keyboard *keyboard,
 }
 
 static const struct wl_keyboard_listener keyboard_listener = {
-  keyboard_keymap,
-  keyboard_enter,
-  keyboard_leave,
-  keyboard_key,
-  keyboard_modifiers,
-  keyboard_repeat_info
-};
+    keyboard_keymap, keyboard_enter,     keyboard_leave,
+    keyboard_key,    keyboard_modifiers, keyboard_repeat_info};
 
 static void FailOnWaylandSetup(Napi::Env env) {
-  Napi::Error::New(env, "Failed to connect to Wayland display").ThrowAsJavaScriptException();
+  Napi::Error::New(env, "Failed to connect to Wayland display")
+      .ThrowAsJavaScriptException();
 }
 
-static void CleanupWaylandContext(WaylandKeymapContext* ctx) {
+static void CleanupWaylandContext(WaylandKeymapContext *ctx) {
   if (ctx->xkb_state)
-      xkb_state_unref(ctx->xkb_state);
+    xkb_state_unref(ctx->xkb_state);
   if (ctx->xkb_keymap)
-      xkb_keymap_unref(ctx->xkb_keymap);
+    xkb_keymap_unref(ctx->xkb_keymap);
   if (ctx->xkb_context)
-      xkb_context_unref(ctx->xkb_context);
+    xkb_context_unref(ctx->xkb_context);
   if (ctx->keyboard)
-      wl_keyboard_destroy(ctx->keyboard);
+    wl_keyboard_destroy(ctx->keyboard);
   if (ctx->seat)
-      wl_seat_destroy(ctx->seat);
+    wl_seat_destroy(ctx->seat);
   if (ctx->registry)
-      wl_registry_destroy(ctx->registry);
+    wl_registry_destroy(ctx->registry);
   if (ctx->display) {
-      wl_display_roundtrip(ctx->display);
-      wl_display_disconnect(ctx->display);
+    wl_display_roundtrip(ctx->display);
+    wl_display_disconnect(ctx->display);
   }
 }
 
-void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
+void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo &info) {
   auto env = info.Env();
 
   // isWayland = detect_display_server() == 1;
@@ -205,20 +203,20 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
 
     waylandContext->display = wl_display_connect(NULL);
     if (!waylandContext->display) {
-      FailOnWaylandSetup(env);
-      return;
+      CleanupWaylandContext(waylandContext);
+      goto x11;
     }
 
     waylandContext->xkb_context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
     if (!waylandContext->xkb_context) {
-      wl_display_disconnect(waylandContext->display);
-      FailOnWaylandSetup(env);
-      return;
+      CleanupWaylandContext(waylandContext);
+      goto x11;
     }
 
     waylandContext->registry = wl_display_get_registry(waylandContext->display);
     std::cout << "Listener!" << std::endl;
-    wl_registry_add_listener(waylandContext->registry, &registry_listener, this);
+    wl_registry_add_listener(waylandContext->registry, &registry_listener,
+                             this);
 
     // Process registry events.
     wl_display_roundtrip(waylandContext->display);
@@ -227,11 +225,8 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
 
     // If a seat was found, add a keyboard listener.
     if (waylandContext->keyboard) {
-      wl_keyboard_add_listener(
-        waylandContext->keyboard,
-        &keyboard_listener,
-        this
-      );
+      wl_keyboard_add_listener(waylandContext->keyboard, &keyboard_listener,
+                               this);
     } else {
       std::cout << "Oof 3!" << std::endl;
       CleanupWaylandContext(waylandContext);
@@ -254,17 +249,16 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
     return;
   }
 
+x11:
+  isWayland = false;
   xDisplay = XOpenDisplay("");
-  CHECK_VOID(
-    xDisplay,
-    "Could not connect to X display",
-    env
-  );
+  CHECK_VOID(xDisplay, "Could not connect to X display", env);
 
   xInputMethod = XOpenIM(xDisplay, 0, 0, 0);
-  if (!xInputMethod) return;
+  if (!xInputMethod)
+    return;
 
-  XIMStyles* styles = 0;
+  XIMStyles *styles = 0;
   if (XGetIMValues(xInputMethod, XNQueryInputStyle, &styles, NULL) || !styles) {
     return;
   }
@@ -272,23 +266,22 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
   XIMStyle bestMatchStyle = 0;
   for (int i = 0; i < styles->count_styles; i++) {
     XIMStyle thisStyle = styles->supported_styles[i];
-    if (thisStyle == (XIMPreeditNothing | XIMStatusNothing))
-    {
+    if (thisStyle == (XIMPreeditNothing | XIMStatusNothing)) {
       bestMatchStyle = thisStyle;
       break;
     }
   }
   XFree(styles);
-  if (!bestMatchStyle) return;
+  if (!bestMatchStyle)
+    return;
 
   Window window;
   int revert_to;
   XGetInputFocus(xDisplay, &window, &revert_to);
   if (window != BadRequest) {
-    xInputContext = XCreateIC(
-      xInputMethod, XNInputStyle, bestMatchStyle, XNClientWindow, window,
-      XNFocusWindow, window, NULL
-    );
+    xInputContext =
+        XCreateIC(xInputMethod, XNInputStyle, bestMatchStyle, XNClientWindow,
+                  window, XNFocusWindow, window, NULL);
   }
 }
 
@@ -298,21 +291,22 @@ void KeyboardLayoutManager::PlatformTeardown() {
   callback.Reset();
 };
 
-void KeyboardLayoutManager::HandleKeyboardLayoutChanged() {
-}
+void KeyboardLayoutManager::HandleKeyboardLayoutChanged() {}
 
 Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(Napi::Env env) {
   Napi::HandleScope scope(env);
   Napi::Value result;
 
   if (isWayland) {
-    if (!waylandContext || !waylandContext->xkb_keymap || !waylandContext->xkb_state) {
+    if (!waylandContext || !waylandContext->xkb_keymap ||
+        !waylandContext->xkb_state) {
       return env.Null();
     }
 
     // Based on lots of experimentation with Gnome/Wayland, the layout at index
     // 0 will always be the active layout.
-    const char* layout_name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, 0);
+    const char *layout_name =
+        xkb_keymap_layout_get_name(waylandContext->xkb_keymap, 0);
 
     result = Napi::String::New(env, layout_name);
   } else {
@@ -323,9 +317,13 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(Napi::Env env) {
       XkbStateRec xkbState;
       XkbGetState(xDisplay, XkbUseCoreKbd, &xkbState);
       if (vdr.variant) {
-        result = Napi::String::New(env, std::string(vdr.layout) + "," + std::string(vdr.variant) + " [" + std::to_string(xkbState.group) + "]");
+        result = Napi::String::New(
+            env, std::string(vdr.layout) + "," + std::string(vdr.variant) +
+                     " [" + std::to_string(xkbState.group) + "]");
       } else {
-        result = Napi::String::New(env, std::string(vdr.layout) + " [" + std::to_string(xkbState.group) + "]");
+        result =
+            Napi::String::New(env, std::string(vdr.layout) + " [" +
+                                       std::to_string(xkbState.group) + "]");
       }
     } else {
       result = env.Null();
@@ -336,17 +334,20 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(Napi::Env env) {
   return result;
 }
 
-Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::CallbackInfo& info) {
+Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(
+    const Napi::CallbackInfo &info) {
   auto env = info.Env();
   return GetCurrentKeyboardLayout(env);
 }
 
-Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLanguage(const Napi::CallbackInfo& info) {
+Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLanguage(
+    const Napi::CallbackInfo &info) {
   // No distinction between “language” and “layout” on Linux.
   return GetCurrentKeyboardLayout(info);
 }
 
-Napi::Value KeyboardLayoutManager::GetInstalledKeyboardLanguages(const Napi::CallbackInfo& info) {
+Napi::Value KeyboardLayoutManager::GetInstalledKeyboardLanguages(
+    const Napi::CallbackInfo &info) {
   auto env = info.Env();
   Napi::HandleScope scope(env);
   return env.Undefined();
@@ -358,19 +359,16 @@ struct KeycodeMapEntry {
 };
 
 #define USB_KEYMAP_DECLARATION static const KeycodeMapEntry keyCodeMap[] =
-#define USB_KEYMAP(usb, evdev, xkb, win, mac, code, id) {xkb, code}
+#define USB_KEYMAP(usb, evdev, xkb, win, mac, code, id)                        \
+  { xkb, code }
 
 #include "keycode_converter_data.inc"
 
-
-Napi::Value CharacterForNativeCodeWayland(
-  Napi::Env env,
-  xkb_context *xkbContext,
-  xkb_keymap *xkbKeymap,
-  xkb_state *xkbState,
-  uint32_t xkbKeycode,
-  uint32_t state
-) {
+Napi::Value CharacterForNativeCodeWayland(Napi::Env env,
+                                          xkb_context *xkbContext,
+                                          xkb_keymap *xkbKeymap,
+                                          xkb_state *xkbState,
+                                          uint32_t xkbKeycode, uint32_t state) {
   if (!xkbContext || !xkbKeymap || !xkbState) {
     return env.Null();
   }
@@ -382,19 +380,18 @@ Napi::Value CharacterForNativeCodeWayland(
   // Map standard modifiers
   struct {
     uint32_t x11_mask;
-    const char* xkb_name;
-  } modifiers[] = {
-    { ShiftMask, XKB_MOD_NAME_SHIFT },
-    { LockMask, XKB_MOD_NAME_CAPS },
-    { ControlMask, XKB_MOD_NAME_CTRL },
-    { Mod1Mask, XKB_MOD_NAME_ALT },
-    // Mod5Mask is often ISO_Level3_Shift (AltGr)
-    { Mod5Mask, "iso_level3_shift" }
-  };
+    const char *xkb_name;
+  } modifiers[] = {{ShiftMask, XKB_MOD_NAME_SHIFT},
+                   {LockMask, XKB_MOD_NAME_CAPS},
+                   {ControlMask, XKB_MOD_NAME_CTRL},
+                   {Mod1Mask, XKB_MOD_NAME_ALT},
+                   // Mod5Mask is often ISO_Level3_Shift (AltGr)
+                   {Mod5Mask, "iso_level3_shift"}};
 
   for (const auto &mod : modifiers) {
     if (state & mod.x11_mask) {
-      xkb_mod_index_t mod_idx = xkb_keymap_mod_get_index(xkbKeymap, mod.xkb_name);
+      xkb_mod_index_t mod_idx =
+          xkb_keymap_mod_get_index(xkbKeymap, mod.xkb_name);
       if (mod_idx != XKB_MOD_INVALID) {
         mod_mask |= (1 << mod_idx);
       }
@@ -413,27 +410,26 @@ Napi::Value CharacterForNativeCodeWayland(
   } else {
     return env.Null();
   }
-
 }
 
-Napi::Value CharacterForNativeCode(Napi::Env env, XIC xInputContext, XKeyEvent *keyEvent, uint xkbKeycode, uint state) {
+Napi::Value CharacterForNativeCode(Napi::Env env, XIC xInputContext,
+                                   XKeyEvent *keyEvent, uint xkbKeycode,
+                                   uint state) {
   keyEvent->keycode = xkbKeycode;
   keyEvent->state = state;
 
   if (xInputContext) {
     wchar_t characters[2];
     char utf8[MB_CUR_MAX * 2 + 1];
-    int count = XwcLookupString(xInputContext, keyEvent, characters, 2, NULL, NULL);
+    int count =
+        XwcLookupString(xInputContext, keyEvent, characters, 2, NULL, NULL);
     size_t len = wcstombs(utf8, characters, sizeof(utf8));
     if (len == (size_t)-1) {
       return env.Null();
     }
 
     if (count > 0 && !std::iswcntrl(characters[0])) {
-      return Napi::String::New(
-        env,
-        std::string(utf8, len)
-      );
+      return Napi::String::New(env, std::string(utf8, len));
     } else {
       return env.Null();
     }
@@ -443,17 +439,15 @@ Napi::Value CharacterForNativeCode(Napi::Env env, XIC xInputContext, XKeyEvent *
     char characters[2];
     int count = XLookupString(keyEvent, characters, 2, NULL, NULL);
     if (count > 0 && !std::iscntrl(characters[0])) {
-      return Napi::String::New(
-        env,
-        std::string(characters, count)
-      );
+      return Napi::String::New(env, std::string(characters, count));
     } else {
       return env.Null();
     }
   }
 }
 
-static char* get_key_char(WaylandKeymapContext *ctx, uint32_t keycode, xkb_mod_mask_t modifiers) {
+static char *get_key_char(WaylandKeymapContext *ctx, uint32_t keycode,
+                          xkb_mod_mask_t modifiers) {
   // At first I thought we needed to offset this by 8, but it already seems
   // correct as-is.
   xkb_keycode_t xkb_keycode = keycode;
@@ -492,7 +486,10 @@ static char* get_key_char(WaylandKeymapContext *ctx, uint32_t keycode, xkb_mod_m
   return result;
 }
 
-static Napi::Value WaylandCharacterForCode(Napi::Env env, WaylandKeymapContext *ctx, uint32_t keycode, xkb_mod_mask_t modifiers) {
+static Napi::Value WaylandCharacterForCode(Napi::Env env,
+                                           WaylandKeymapContext *ctx,
+                                           uint32_t keycode,
+                                           xkb_mod_mask_t modifiers) {
   char *result = get_key_char(ctx, keycode, modifiers);
   if (result) {
     auto wrappedResult = Napi::String::New(env, result);
@@ -503,13 +500,15 @@ static Napi::Value WaylandCharacterForCode(Napi::Env env, WaylandKeymapContext *
   }
 }
 
-Napi::Value KeyboardLayoutManager::GetCurrentKeymap(const Napi::CallbackInfo& info) {
+Napi::Value
+KeyboardLayoutManager::GetCurrentKeymap(const Napi::CallbackInfo &info) {
   auto env = info.Env();
   Napi::Object result = Napi::Object::New(env);
   Napi::String unmodifiedKey = Napi::String::New(env, "unmodified");
   Napi::String withShiftKey = Napi::String::New(env, "withShift");
   Napi::String withAltGraphKey = Napi::String::New(env, "withAltGraph");
-  Napi::String withAltGraphShiftKey = Napi::String::New(env, "withAltGraphShift");
+  Napi::String withAltGraphShiftKey =
+      Napi::String::New(env, "withAltGraphShift");
 
   if (isWayland) {
     size_t keyCodeMapSize = sizeof(keyCodeMap) / sizeof(keyCodeMap[0]);
@@ -518,9 +517,10 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeymap(const Napi::CallbackInfo& in
       uint xkbKeycode = keyCodeMap[i].xkbKeycode;
       if (dom3Code && xkbKeycode > 0x0000) {
         Napi::String dom3CodeKey = Napi::String::New(env, dom3Code);
-        Napi::Value unmodified = WaylandCharacterForCode(env, waylandContext, xkbKeycode, 0);
-        Napi::Value withShift =
-            WaylandCharacterForCode(env, waylandContext, xkbKeycode, waylandContext->shift_mask);
+        Napi::Value unmodified =
+            WaylandCharacterForCode(env, waylandContext, xkbKeycode, 0);
+        Napi::Value withShift = WaylandCharacterForCode(
+            env, waylandContext, xkbKeycode, waylandContext->shift_mask);
         Napi::Value withAltGraph = WaylandCharacterForCode(
             env, waylandContext, xkbKeycode, waylandContext->alt_gr_mask);
         Napi::Value withAltGraphShift = WaylandCharacterForCode(
@@ -540,7 +540,8 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeymap(const Napi::CallbackInfo& in
     }
   } else {
     // Clear cached keymap.
-    XMappingEvent eventMap = {MappingNotify, 0, false, xDisplay, 0, MappingKeyboard, 0, 0};
+    XMappingEvent eventMap = {MappingNotify,   0, false, xDisplay, 0,
+                              MappingKeyboard, 0, 0};
     XRefreshKeyboardMapping(&eventMap);
 
     XkbStateRec xkbState;
@@ -555,7 +556,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeymap(const Napi::CallbackInfo& in
     // Set up an event to reuse across CharacterForNativeCode calls.
     XEvent event;
     memset(&event, 0, sizeof(XEvent));
-    XKeyEvent* keyEvent = &event.xkey;
+    XKeyEvent *keyEvent = &event.xkey;
     keyEvent->display = xDisplay;
     keyEvent->type = KeyPress;
 
@@ -566,8 +567,11 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeymap(const Napi::CallbackInfo& in
 
       if (dom3Code && xkbKeycode > 0x0000) {
         Napi::String dom3CodeKey = Napi::String::New(env, dom3Code);
-        Napi::Value unmodified = CharacterForNativeCode(env, xInputContext, keyEvent, xkbKeycode, keyboardBaseState);
-        Napi::Value withShift = CharacterForNativeCode(env, xInputContext, keyEvent, xkbKeycode, keyboardBaseState | ShiftMask);
+        Napi::Value unmodified = CharacterForNativeCode(
+            env, xInputContext, keyEvent, xkbKeycode, keyboardBaseState);
+        Napi::Value withShift =
+            CharacterForNativeCode(env, xInputContext, keyEvent, xkbKeycode,
+                                   keyboardBaseState | ShiftMask);
 
         if (unmodified.IsString() || withShift.IsString()) {
           Napi::Object entry = Napi::Object::New(env);
@@ -583,7 +587,8 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeymap(const Napi::CallbackInfo& in
 }
 
 void KeyboardLayoutManager::SetupWaylandPolling() {
-  if (!waylandContext || !waylandContext->display) return;
+  if (!waylandContext || !waylandContext->display)
+    return;
 
   int fd = wl_display_get_fd(waylandContext->display);
 
@@ -594,7 +599,7 @@ void KeyboardLayoutManager::SetupWaylandPolling() {
   uv_poll_start(waylandPoll, UV_READABLE, OnWaylandEvent);
 
   // Unref the handles so they don't prevent process exit
-  uv_unref((uv_handle_t*)waylandPoll);
+  uv_unref((uv_handle_t *)waylandPoll);
 
   // // Create a check handle that runs in each iteration of the event loop
   // exit_check = new uv_check_t;
@@ -603,7 +608,8 @@ void KeyboardLayoutManager::SetupWaylandPolling() {
   //
   // // Start the check handle
   // uv_check_start(exit_check, [](uv_check_t* handle) {
-  //   KeyboardLayoutManager* manager = static_cast<KeyboardLayoutManager*>(handle->data);
+  //   KeyboardLayoutManager* manager =
+  //   static_cast<KeyboardLayoutManager*>(handle->data);
   //
   //   // If we're allowing exit and no other active handles exist except ours,
   //   // then unref our handles to allow process to exit
@@ -621,6 +627,7 @@ void KeyboardLayoutManager::SetupWaylandPolling() {
 
 void KeyboardLayoutManager::OnWaylandEvent(uv_poll_t *handle, int status,
                                            int events) {
+  std::cout << "OnWaylandEvent!" << std::endl;
   KeyboardLayoutManager *instance =
       static_cast<KeyboardLayoutManager *>(handle->data);
   if (status < 0) {
@@ -645,7 +652,6 @@ void KeyboardLayoutManager::CleanupWaylandPolling() {
     waylandPoll = nullptr;
   }
 }
-
 
 void KeyboardLayoutManager::ProcessCallbackWrapper() {
   ProcessCallback(_env, callback.Value().As<Napi::Function>());

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -340,8 +340,22 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
   Napi::Value result;
 
   if (isWayland) {
-    // TODO
-    return env.Null();
+    if (!waylandContext || !waylandContext->xkb_keymap) {
+      return env.Null();
+    }
+
+    char layout_id[256] = {0};
+
+    xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(waylandContext->xkb_keymap);
+    xkb_layout_index_t active_layout = 0;
+
+    const char* active_layout_name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, i);
+    if (!active_layout_name) {
+      return env.Null();
+    }
+
+    strcat(layout_id, layout_name);
+    return Napi::String::New(env, layout_name);
   } else {
     // X11
     XkbRF_VarDefsRec vdr;
@@ -476,7 +490,8 @@ Napi::Value CharacterForNativeCode(Napi::Env env, XIC xInputContext, XKeyEvent *
 }
 
 static char* get_key_char(WaylandKeymapContext *ctx, uint32_t keycode, xkb_mod_mask_t modifiers) {
-  // XKB keycodes are offset by 8 from evdev keycodes.
+  // At first I thought we needed to offset this by 8, but it already seems
+  // correct as-is.
   xkb_keycode_t xkb_keycode = keycode;
 
   // Create a copy of the XKB state so we can apply modifiers.

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -315,7 +315,9 @@ Napi::Value CharacterForNativeCodeWayland(
   Napi::Env env,
   xkb_context *xkbContext,
   xkb_keymap *xkbKeymap,
-  xkb_state *xkbState
+  xkb_state *xkbState,
+  uint32_t xkbKeycode,
+  uint32_t state
 ) {
   if (!xkbContext || !xkbKeymap || !xkbState) {
     return env.Null();

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -219,22 +219,18 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
 
           std::cout << "First layout name: " << layout_name << std::endl;
 
-          // Add null checks before string construction
-          std::string layout_str = names.layout ? std::string(names.layout) : "unknown";
-          std::string variant_str = names.variant ? std::string(names.variant) : "";
+          result = Napi::String::New(env, layout_name);
 
-          if (!variant_str.empty()) {
-            result = Napi::String::New(env, layout_str + "," + variant_str);
-          } else {
-            result = Napi::String::New(env, layout_str);
-          }
+          // Add null checks before string construction
+          // std::string layout_str = names.layout ? std::string(names.layout) : "unknown";
+          // std::string variant_str = names.variant ? std::string(names.variant) : "";
+
+          // if (!variant_str.empty()) {
+          //   result = Napi::String::New(env, layout_str + "," + variant_str);
+          // } else {
+          //   result = Napi::String::New(env, layout_str);
+          // }
         }
-        // if (num_layouts > 0) {
-        //   layout_name = strdup(xkb_keymap_layout_get_name(keymap, 0));
-        //   result = Napi::String::New(env, std::string(names.layout) + "," + std::string(names.variant));
-        // } else {
-        //   result = env.Null();
-        // }
       }
       xkb_keymap_unref(keymap);
       xkb_context_unref(context);

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -101,7 +101,8 @@ static const struct wl_registry_listener registry_listener = {
 // Keyboard listener callbacks
 static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
                             uint32_t format, int32_t fd, uint32_t size) {
-  auto ctx = (static_cast<KeyboardLayoutManager *>(data))->waylandContext;
+  auto that = (static_cast<KeyboardLayoutManager *>(data));
+  auto ctx = that->waylandContext;
 
   if (format != WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1) {
     close(fd);

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -619,5 +619,5 @@ void KeyboardLayoutManager::CleanupWaylandPolling() {
 
 
 void KeyboardLayoutManager::ProcessCallbackWrapper() {
-  ProcessCallback(_env, callback);
+  ProcessCallback(_env, callback.Value().As<Napi::Function>();
 }

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -461,6 +461,8 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeymap(const Napi::CallbackInfo& in
           (entry).Set(unmodifiedKey, unmodified);
           (entry).Set(withShiftKey, withShift);
           (result).Set(dom3CodeKey, entry);
+        } else {
+          std::cout << "No luck for: " << dom3Code << std::endl;
         }
       }
     }

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -265,6 +265,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
     }
   }
 
+  std::cout << "Returning!" << std::endl;
   return result;
 }
 

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -354,85 +354,127 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
 
     xkb_state_update_mask(temp_state_with_shift, shift_mask, 0, 0, 0, 0 , 0);
 
-    // xkb_layout_index_t active_layout = xkb_state_key_get_layout(waylandContext->xkb_state, XKB_STATE_LAYOUT_EFFECTIVE);
-    //
-    // const char* active_layout_name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, group);
-    //
-    // if (active_layout_name) {
-    //   return Napi::String::New(env, active_layout_name);
-    // }
-
-    // Keys to test - include a variety of keys from different parts of keyboard
-    const xkb_keycode_t test_keys[] = {
-      38 + 8, // a
-      39 + 8, // s
-      40 + 8, // d
-      41 + 8, // f
-      44 + 8, // j
-      45 + 8, // k
-      46 + 8, // l
-      24 + 8, // q
-      25 + 8, // w
-      30 + 8, // u
-      31 + 8, // i
-      32 + 8, // o
-      33 + 8, // p
-      57 + 8, // space
-      28 + 8, // t
-      29 + 8, // y
-      51 + 8, // hash/pound sign (#)
-    };
-
-    // Count how many times each layout index responds
-    std::unordered_map<xkb_layout_index_t, int> layout_scores;
-
-    // Get number of layouts
+    // Create fingerprints for each layout
+    std::vector<std::string> layout_fingerprints;
     xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(waylandContext->xkb_keymap);
 
+
+    // For each layout, create a test state
+    for (xkb_layout_index_t layout = 0; layout < num_layouts; layout++) {
+        // Create a new state with just this layout active
+        xkb_state* test_state = xkb_state_new(ctx->xkb_keymap);
+
+        // Set the active group (layout)
+        xkb_state_update_mask(test_state, 0, 0, 0, layout, 0, 0);
+
+        // Build a fingerprint of key mappings for this layout
+        std::string fingerprint;
+        const xkb_keycode_t test_keys[] = { 38+8, 39+8, 40+8 }; // a, s, d
+
+        for (auto key : test_keys) {
+            xkb_keysym_t sym = xkb_state_key_get_one_sym(test_state, key);
+            char buf[8] = {0};
+            xkb_keysym_to_utf8(sym, buf, sizeof(buf));
+            fingerprint += buf;
+        }
+
+        layout_fingerprints.push_back(fingerprint);
+        xkb_state_unref(test_state);
+    }
+
+    // Now get the fingerprint of the current active state
+    std::string current_fingerprint;
+    const xkb_keycode_t test_keys[] = {38 + 8, 39 + 8, 40 + 8}; // a, s, d
+
     for (auto key : test_keys) {
-      xkb_layout_index_t layout_index_for_key;
-      if (key == 59) {
-        layout_index_for_key = xkb_state_key_get_layout(temp_state_with_shift, key);
-      } else  {
-        layout_index_for_key = xkb_state_key_get_layout(temp_state, key);
-      }
-      if (layout_index_for_key < num_layouts) {
-        layout_scores[layout_index_for_key]++;
-      }
-      const char* name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, layout_index_for_key);
-      std::cout << "Key " << key << " handled by layout " << name << " at index " << layout_index_for_key << std::endl;
+      xkb_keysym_t sym = xkb_state_key_get_one_sym(original_state, key);
+      char buf[8] = {0};
+      xkb_keysym_to_utf8(sym, buf, sizeof(buf));
+      current_fingerprint += buf;
     }
 
-    std::vector<std::pair<xkb_layout_index_t, int>> score_pairs;
-    for (const auto &pair : layout_scores) {
-      score_pairs.push_back(pair);
-    }
+    std::cout << "Current fingerprint: " << current_fingerprint << std::endl;
 
-    // Sort by score (descending)
-    std::sort(score_pairs.begin(), score_pairs.end(),
-              [](const auto &a, const auto &b) { return a.second > b.second; });
-
-    std::stringstream ss;
-    bool first = true;
-
-    for (const auto &pair : score_pairs) {
-      xkb_layout_index_t idx = pair.first;
-      int score = pair.second;
-
-      const char* name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, idx);
-      std::string layout_name = name ? name : std::string("layout-") + std::to_string(idx);
-
-      if (!first) {
-        ss << ", ";
+    // Find the matching layout
+    for (xkb_layout_index_t i = 0; i < layout_fingerprints.size(); i++) {
+      if (layout_fingerprints[i] == current_fingerprint) {
+        const char *name = xkb_keymap_layout_get_name(ctx->xkb_keymap, i);
+        return Napi::String::New(env, name ? name : std::string("layout-") + std::to_string(i));
+        // name ? name : std::string("layout-") + std::to_string(i);
       }
-      ss << layout_name;
-      first = false;
     }
 
-    xkb_state_unref(temp_state);
-    xkb_state_unref(temp_state_with_shift);
-
-    return Napi::String::New(env, ss.str());
+    // // Keys to test - include a variety of keys from different parts of keyboard
+    // const xkb_keycode_t test_keys[] = {
+    //   38 + 8, // a
+    //   39 + 8, // s
+    //   40 + 8, // d
+    //   41 + 8, // f
+    //   44 + 8, // j
+    //   45 + 8, // k
+    //   46 + 8, // l
+    //   24 + 8, // q
+    //   25 + 8, // w
+    //   30 + 8, // u
+    //   31 + 8, // i
+    //   32 + 8, // o
+    //   33 + 8, // p
+    //   57 + 8, // space
+    //   28 + 8, // t
+    //   29 + 8, // y
+    //   51 + 8, // hash/pound sign (#)
+    // };
+    //
+    // // Count how many times each layout index responds
+    // std::unordered_map<xkb_layout_index_t, int> layout_scores;
+    //
+    // // Get number of layouts
+    // xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(waylandContext->xkb_keymap);
+    //
+    // for (auto key : test_keys) {
+    //   xkb_layout_index_t layout_index_for_key;
+    //   if (key == 59) {
+    //     layout_index_for_key = xkb_state_key_get_layout(temp_state_with_shift, key);
+    //   } else  {
+    //     layout_index_for_key = xkb_state_key_get_layout(temp_state, key);
+    //   }
+    //   if (layout_index_for_key < num_layouts) {
+    //     layout_scores[layout_index_for_key]++;
+    //   }
+    //   const char* name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, layout_index_for_key);
+    //   std::cout << "Key " << key << " handled by layout " << name << " at index " << layout_index_for_key << std::endl;
+    // }
+    //
+    // std::vector<std::pair<xkb_layout_index_t, int>> score_pairs;
+    // for (const auto &pair : layout_scores) {
+    //   score_pairs.push_back(pair);
+    // }
+    //
+    // // Sort by score (descending)
+    // std::sort(score_pairs.begin(), score_pairs.end(),
+    //           [](const auto &a, const auto &b) { return a.second > b.second; });
+    //
+    // std::stringstream ss;
+    // bool first = true;
+    //
+    // for (const auto &pair : score_pairs) {
+    //   xkb_layout_index_t idx = pair.first;
+    //   int score = pair.second;
+    //
+    //   const char* name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, idx);
+    //   std::string layout_name = name ? name : std::string("layout-") + std::to_string(idx);
+    //
+    //   if (!first) {
+    //     ss << ", ";
+    //   }
+    //   ss << layout_name;
+    //   first = false;
+    // }
+    //
+    // xkb_state_unref(temp_state);
+    // xkb_state_unref(temp_state_with_shift);
+    //
+    // return Napi::String::New(env, ss.str());
   } else {
     // X11
     XkbRF_VarDefsRec vdr;

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -374,11 +374,11 @@ std::string KeyboardLayoutManager::GetCurrentKeyboardLayout() {
 Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(Napi::Env env) {
   Napi::HandleScope scope(env);
 
-  const char* rawResult = GetCurrentKeyboardLayout();
-  if (strcmp(rawResult, "") == 0) {
+  std::string rawResult = GetCurrentKeyboardLayout();
+  if (rawResult == "") {
     return env.Null();
   }
-  return Napi::String::New(env, rawResult);
+  return Napi::String::New(env, rawResult.c_str());
 }
 
 void KeyboardLayoutManager::ProcessCallback(

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -380,7 +380,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(Napi::Env env) {
   return Napi::String::New(env, rawResult);
 }
 
-void KeyboardLayoutManager::ProcessCallback(
+static void KeyboardLayoutManager::ProcessCallback(
   Napi::Env env,
   Napi::Function callback
 ) {

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -132,10 +132,12 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
     struct xkb_keymap *keymap = nullptr;
     bool gotKeymap = GetWaylandKeymap(context, &keymap);
     if (gotKeymap) {
+      std::cout << "GOT KEYMAP!" << std::endl;
       xkbContext = context;
       xkbKeymap = keymap;
       return;
     }
+    std::cout << "FALLBACK!" << std::endl;
     // KeyboardMonitor* monitor = calloc(1, sizeof(KeyboardMonitor));
     // if (!monitor) {
     //   return;

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -400,7 +400,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
         layout_scores[layout_index_for_key]++;
       }
       const char* name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, layout_index_for_key);
-      std::cout << "Key " << key << " handled by layout " << name << std::endl;
+      std::cout << "Key " << key << " handled by layout " << name << " at index " << layout_index_for_key << std::endl;
     }
 
     std::vector<std::pair<xkb_layout_index_t, int>> score_pairs;

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -594,7 +594,7 @@ void KeyboardLayoutManager::SetupWaylandPolling() {
   uv_poll_start(waylandPoll, UV_READABLE, OnWaylandEvent);
 
   // Unref the handles so they don't prevent process exit
-  uv_unref((uv_handle_t*)wayland_poll);
+  uv_unref((uv_handle_t*)waylandPoll);
 
   // // Create a check handle that runs in each iteration of the event loop
   // exit_check = new uv_check_t;

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -403,7 +403,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
 
     for (auto key : test_keys) {
       xkb_layout_index_t layout_index_for_key;
-      if (test_key === 59) {
+      if (key == 59) {
         layout_index_for_key = xkb_state_key_get_layout(temp_state_with_shift, key);
       } else  {
         layout_index_for_key = xkb_state_key_get_layout(temp_state, key);

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -99,7 +99,6 @@ static const struct wl_registry_listener registry_listener = {
 static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
                             uint32_t format, int32_t fd, uint32_t size) {
 
-  std::cout << "in keyboard_keymap" << std::endl;
   // auto env = (static_cast<Napi::Env*>(data));
   // auto that = env->GetInstanceData<KeyboardLayoutManager>();
   auto that = (static_cast<KeyboardLayoutManager *>(data));

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -440,11 +440,11 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeymap(const Napi::CallbackInfo& in
 
   if (isWayland) {
     size_t keyCodeMapSize = sizeof(keyCodeMap) / sizeof(keyCodeMap[0]);
-    for (size_t i = 0; i < keyCodeMapSizel i++) {
+    for (size_t i = 0; i < keyCodeMapSize; i++) {
       const char *dom3Code = keyCodeMap[i].dom3Code;
-      uint xkbKeyCode = keyCodeMap[i].xkbKeyCode;
+      uint xkbKeycode = keyCodeMap[i].xkbKeycode;
 
-      if (dom3Code && xkbKeyCode > 0x0000) {
+      if (dom3Code && xkbKeycode > 0x0000) {
         Napi::String dom3CodeKey = Napi::String::New(env, dom3Code);
         Napi::Value unmodified = CharacterForNativeCodeWayland(env, xkbContext, xkbKeymap, xkbState, xjbKeycode, keyboardBaseState);
         Napi::Value withShift = CharacterForNativeCodeWayland(env, xkbContext, xkbKeymap, xkbState, keyboardBaseState | ShiftMask);

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -235,60 +235,59 @@ static void CleanupWaylandContext(WaylandKeymapContext *ctx) {
 void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo &info) {
   auto env = info.Env();
 
-  // isWayland = detect_display_server() == 1;
+  // Assume we're on Wayland to start out.
   isWayland = true;
 
-  if (isWayland) {
-    waylandContext = new WaylandKeymapContext();
-    memset(waylandContext, 0, sizeof(WaylandKeymapContext));
+  waylandContext = new WaylandKeymapContext();
+  memset(waylandContext, 0, sizeof(WaylandKeymapContext));
 
-    waylandContext->display = wl_display_connect(NULL);
-    if (!waylandContext->display) {
-      CleanupWaylandContext(waylandContext);
-      goto x11;
-    }
-
-    waylandContext->xkb_context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
-    if (!waylandContext->xkb_context) {
-      CleanupWaylandContext(waylandContext);
-      goto x11;
-    }
-
-    waylandContext->registry = wl_display_get_registry(waylandContext->display);
-    std::cout << "Listener!" << std::endl;
-    wl_registry_add_listener(waylandContext->registry, &registry_listener,
-                             this);
-
-    // Process registry events.
-    wl_display_roundtrip(waylandContext->display);
-
-    std::cout << "Got this far 1!" << std::endl;
-
-    // If a seat was found, add a keyboard listener.
-    if (waylandContext->keyboard) {
-      wl_keyboard_add_listener(waylandContext->keyboard, &keyboard_listener,
-                               this);
-    } else {
-      std::cout << "Oof 3!" << std::endl;
-      CleanupWaylandContext(waylandContext);
-      FailOnWaylandSetup(env);
-      return;
-    }
-
-    std::cout << "Got this far 2!" << std::endl;
-    // Wait for the keymap to be received.
-    while (!waylandContext->keymap_received) {
-      if (wl_display_dispatch(waylandContext->display) < 0) {
-        CleanupWaylandContext(waylandContext);
-        FailOnWaylandSetup(env);
-        return;
-      }
-    }
-
-    SetupWaylandPolling();
-    // We're good. We can exit.
-    return;
+  waylandContext->display = wl_display_connect(NULL);
+  if (!waylandContext->display) {
+    CleanupWaylandContext(waylandContext);
+    goto x11;
   }
+
+  waylandContext->xkb_context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+  if (!waylandContext->xkb_context) {
+    CleanupWaylandContext(waylandContext);
+    goto x11;
+  }
+
+  // If we can get as far as creating a Wayland display and context, it is
+  // assumed that we are on Wayland and not X11. But since any failure further
+  // along the Wayland path of this function is fatal, there's no reason not to
+  // at least _try_ to fallback to X11.
+
+  waylandContext->registry = wl_display_get_registry(waylandContext->display);
+  std::cout << "Listener!" << std::endl;
+  wl_registry_add_listener(waylandContext->registry, &registry_listener,
+                           this);
+
+  // Process registry events.
+  wl_display_roundtrip(waylandContext->display);
+
+  // If a seat was found, add a keyboard listener.
+  if (waylandContext->keyboard) {
+    wl_keyboard_add_listener(waylandContext->keyboard, &keyboard_listener,
+                             this);
+  } else {
+    CleanupWaylandContext(waylandContext);
+    goto x11;
+  }
+
+  // Wait for the keymap to be received.
+  while (!waylandContext->keymap_received) {
+    if (wl_display_dispatch(waylandContext->display) < 0) {
+      CleanupWaylandContext(waylandContext);
+      goto x11;
+    }
+  }
+
+  // Once we've gotten this far, we have everything we need to inspect keyboard
+  // behavior. Now we'll set up polling on the event loop so we can find out
+  // when the keyboard layout changes.
+  SetupWaylandPolling();
+  return;
 
 x11:
   isWayland = false;
@@ -332,9 +331,9 @@ void KeyboardLayoutManager::PlatformTeardown() {
   callback.Reset();
 };
 
-void KeyboardLayoutManager::HandleKeyboardLayoutChanged() {}
-
-Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(Napi::Env env) {
+Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(
+    const Napi::CallbackInfo &info) {
+  auto env = info.Env();
   Napi::HandleScope scope(env);
   Napi::Value result;
 
@@ -345,11 +344,16 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(Napi::Env env) {
     }
 
     // Based on lots of experimentation with Gnome/Wayland, the layout at index
-    // 0 will always be the active layout.
+    // 0 will always be the active layout. This may or may not be true for
+    // other Wayland server implementations, but we'll go with it for now —
+    // because if it isn't true, we'd be hard-pressed to discover that
+    // information any other way.
     const char *layout_name =
         xkb_keymap_layout_get_name(waylandContext->xkb_keymap, 0);
 
+#ifdef DEBUG
     std::cout << "Current layout: " << layout_name << std::endl;
+#endif
     result = Napi::String::New(env, layout_name);
   } else {
     // X11
@@ -372,12 +376,6 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(Napi::Env env) {
     }
   }
   return result;
-}
-
-Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(
-    const Napi::CallbackInfo &info) {
-  auto env = info.Env();
-  return GetCurrentKeyboardLayout(env);
 }
 
 Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLanguage(

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -344,18 +344,24 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
       return env.Null();
     }
 
-    xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(waylandContext->xkb_keymap);
-    xkb_layout_index_t active_layout_index = 0;
-    if (waylandContext->xkb_state) {
-      active_layout_index = xkb_state_serialize_layout(waylandContext->xkb_state);
+    // Get layout names - this is usually what you want for identification
+    char layout_id[256] = {0};
+
+    // Get number of layouts
+    xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(ctx->xkb_keymap);
+
+    // Build a string with all layout names
+    for (xkb_layout_index_t i = 0; i < num_layouts; i++) {
+      const char* layout_name = xkb_keymap_layout_get_name(ctx->xkb_keymap, i);
+      if (layout_name) {
+        if (i > 0) {
+          strcat(layout_id, ",");
+        }
+        strcat(layout_id, layout_name);
+      }
     }
 
-    const char* active_layout_name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, active_layout_index);
-    if (!active_layout_name) {
-      return env.Null();
-    }
-
-    return Napi::String::New(env, active_layout_name);
+    return Napi::String::New(env, layout_id);
   } else {
     // X11
     XkbRF_VarDefsRec vdr;

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -301,8 +301,7 @@ void KeyboardLayoutManager::PlatformTeardown() {
 void KeyboardLayoutManager::HandleKeyboardLayoutChanged() {
 }
 
-Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::CallbackInfo& info) {
-  auto env = info.Env();
+Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(Napi::Env env) {
   Napi::HandleScope scope(env);
   Napi::Value result;
 
@@ -335,6 +334,11 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
 
   std::cout << "Returning!" << std::endl;
   return result;
+}
+
+Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::CallbackInfo& info) {
+  auto env = info.Env();
+  return GetCurrentKeyboardLayout(env);
 }
 
 Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLanguage(const Napi::CallbackInfo& info) {

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -371,6 +371,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
       57 + 8, // space
       28 + 8, // t
       29 + 8, // y
+      52 + 8, // dollar sign ($)
     };
 
     // Count how many times each layout index responds

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -335,6 +335,8 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(Napi::Env env) {
   Napi::HandleScope scope(env);
   Napi::Value result;
 
+  return Napi::String::New(env, "test_layout_hardcoded_awesome");
+
   if (isWayland) {
     if (!waylandContext || !waylandContext->xkb_keymap ||
         !waylandContext->xkb_state) {

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -91,6 +91,37 @@ static int detect_display_server() {
   return -1;
 }
 
+static bool GetWaylandKeymap(xkb_context *context, xkb_keymap **keymap) {
+  // Try to find the keymap in the XDG runtime dir
+  const char *xdg_runtime = getenv("XDG_RUNTIME_DIR");
+  if (!xdg_runtime)
+    return false;
+
+  // Construct path to the active keymap if it exists
+  std::string keymap_path = std::string(xdg_runtime) + "/keymap";
+  FILE *f = fopen(keymap_path.c_str(), "r");
+  if (!f)
+    return false;
+
+  // Read the keymap string
+  fseek(f, 0, SEEK_END);
+  long size = ftell(f);
+  fseek(f, 0, SEEK_SET);
+
+  char *keymap_string = new char[size + 1];
+  fread(keymap_string, 1, size, f);
+  keymap_string[size] = '\0';
+  fclose(f);
+
+  // Create keymap from the string
+  *keymap = xkb_keymap_new_from_string(context, keymap_string,
+                                       XKB_KEYMAP_FORMAT_TEXT_V1,
+                                       XKB_KEYMAP_COMPILE_NO_FLAGS);
+
+  delete[] keymap_string;
+  return (*keymap != nullptr);
+}
+
 void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
   auto env = info.Env();
 

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -13,11 +13,6 @@
 #include <iostream>
 #include <locale.h>
 
-struct CallbackContext {
-  KeyboardLayoutManager* instance;
-  Napi::Env env;
-};
-
 // More robust detection combining multiple checks
 static int detect_display_server() {
   // Method 1: XDG_SESSION_TYPE - Can be most reliable when set correctly
@@ -197,11 +192,6 @@ static void CleanupWaylandContext(WaylandKeymapContext* ctx) {
       wl_display_disconnect(ctx->display);
   }
 }
-
-struct CallbackContext {
-  KeyboardLayoutManager *instance;
-  Napi::Env env;
-};
 
 void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
   auto env = info.Env();

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -331,16 +331,11 @@ void KeyboardLayoutManager::PlatformTeardown() {
 
 void KeyboardLayoutManager::HandleKeyboardLayoutChanged() {}
 
-Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(Napi::Env env) {
-  Napi::HandleScope scope(env);
-  Napi::Value result;
-
-  return Napi::String::New(env, "test_layout_hardcoded_awesome");
-
+const char* KeyboardLayoutManager::GetCurrentKeyboardLayout() {
   if (isWayland) {
     if (!waylandContext || !waylandContext->xkb_keymap ||
         !waylandContext->xkb_state) {
-      return env.Null();
+      return "";
     }
 
     // Based on lots of experimentation with Gnome/Wayland, the layout at index
@@ -350,7 +345,8 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(Napi::Env env) {
 
     std::cout << "Current layout: " << layout_name << std::endl;
     currentLayout = layout_name;
-    result = Napi::String::New(env, layout_name);
+    result = layout_name;
+    // result = Napi::String::New(env, layout_name);
   } else {
     // X11
     XkbRF_VarDefsRec vdr;
@@ -359,20 +355,30 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(Napi::Env env) {
       XkbStateRec xkbState;
       XkbGetState(xDisplay, XkbUseCoreKbd, &xkbState);
       if (vdr.variant) {
-        result = Napi::String::New(
-            env, std::string(vdr.layout) + "," + std::string(vdr.variant) +
-                     " [" + std::to_string(xkbState.group) + "]");
+        result = (std::string(vdr.layout) + "," + std::string(vdr.variant) +
+                 " [" + std::to_string(xkbState.group) + "]");
+        // result = Napi::String::New(
+        //     env, );
       } else {
-        result =
-            Napi::String::New(env, std::string(vdr.layout) + " [" +
-                                       std::to_string(xkbState.group) + "]");
+        result = std::string(vdr.layout) + " [" +
+                                   std::to_string(xkbState.group) + "]";
+            // Napi::String::New(env, );
       }
     } else {
-      result = env.Null();
+      result = "";
     }
   }
-
   return result;
+}
+
+Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(Napi::Env env) {
+  Napi::HandleScope scope(env);
+
+  const char* rawResult = GetCurrentKeyboardLayout();
+  if (rawResult == "") {
+    return env.Null();
+  }
+  return Napi::String::New(env, rawResult);
 }
 
 Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -439,6 +439,13 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeymap(const Napi::CallbackInfo& in
   Napi::String withShiftKey = Napi::String::New(env, "withShift");
 
   if (isWayland) {
+    uint keyboardBaseState = 0x0000;
+    // if (xkbState.group == 1) {
+    //   keyboardBaseState = 0x2000;
+    // } else if (xkbState.group == 2) {
+    //   keyboardBaseState = 0x4000;
+    // }
+
     size_t keyCodeMapSize = sizeof(keyCodeMap) / sizeof(keyCodeMap[0]);
     for (size_t i = 0; i < keyCodeMapSize; i++) {
       const char *dom3Code = keyCodeMap[i].dom3Code;
@@ -446,7 +453,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeymap(const Napi::CallbackInfo& in
 
       if (dom3Code && xkbKeycode > 0x0000) {
         Napi::String dom3CodeKey = Napi::String::New(env, dom3Code);
-        Napi::Value unmodified = CharacterForNativeCodeWayland(env, xkbContext, xkbKeymap, xkbState, xjbKeycode, keyboardBaseState);
+        Napi::Value unmodified = CharacterForNativeCodeWayland(env, xkbContext, xkbKeymap, xkbState, xkbKeycode, keyboardBaseState);
         Napi::Value withShift = CharacterForNativeCodeWayland(env, xkbContext, xkbKeymap, xkbState, keyboardBaseState | ShiftMask);
 
         if (unmodified.IsString() || withShift.IsString()) {

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -348,11 +348,11 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
     char layout_id[256] = {0};
 
     // Get number of layouts
-    xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(ctx->xkb_keymap);
+    xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(waylandContext->xkb_keymap);
 
     // Build a string with all layout names
     for (xkb_layout_index_t i = 0; i < num_layouts; i++) {
-      const char* layout_name = xkb_keymap_layout_get_name(ctx->xkb_keymap, i);
+      const char* layout_name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, i);
       if (layout_name) {
         if (i > 0) {
           strcat(layout_id, ",");

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -79,6 +79,7 @@ static const struct wl_registry_listener registry_listener = {
 static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
                             uint32_t format, int32_t fd, uint32_t size) {
 
+  std::cout << "In keyboard_keymap!" << std::endl;
   WaylandKeymapContext *ctx = (WaylandKeymapContext *)data;
 
   if (format != WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1) {
@@ -237,7 +238,7 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
       wl_keyboard_add_listener(
         waylandContext->keyboard,
         &keyboard_listener,
-        NULL
+        waylandContext
       );
     } else {
       std::cout << "Oof 3!" << std::endl;

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -9,6 +9,7 @@
 #include <cwctype>
 #include <cctype>
 #include <stdio.h>
+#include <sstream>
 #include <iostream>
 #include <locale.h>
 
@@ -380,7 +381,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
 
     for (auto key : test_keys) {
       xkb_layout_index_t layout_index_for_key = xkb_state_key_get_layout(waylandContext->xkb_state, key);
-      if (layout < num_layouts) {
+      if (layout_index_for_key < num_layouts) {
         layout_scores[layout_index_for_key]++;
       }
     }
@@ -393,9 +394,6 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
     // Sort by score (descending)
     std::sort(score_pairs.begin(), score_pairs.end(),
               [](const auto &a, const auto &b) { return a.second > b.second; });
-
-    // Get number of layouts
-    xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(waylandContext->xkb_keymap);
 
     std::stringstream ss;
     bool first = true;
@@ -424,7 +422,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
     //     strcat(layout_id, layout_name);
     //   }
     // }
-    
+
     return Napi::String::New(env, ss.str());
   } else {
     // X11

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -356,6 +356,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
     // Build a string with all layout names
     for (xkb_layout_index_t i = 0; i < num_layouts; i++) {
       const char* layout_name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, i);
+      std::cout << "Layout " << i << " is " << layout_name << std::endl;
       if (layout_name) {
         if (i > 0) {
           strcat(layout_id, ",");

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -12,27 +12,6 @@
 #include <unistd.h>
 #include <xkbcommon/xkbcommon.h>
 
-static void PrintModifierInfo(WaylandKeymapContext *ctx,
-                              xkb_mod_index_t mod_idx) {
-  const char* mod_name = xkb_keymap_mod_get_name(ctx->xkb_keymap, mod_idx);
-  std::cout << "Mod name: " << mod_name << std::endl;
-
-  // List which keys are mapped to this modifier
-  for (xkb_keycode_t keycode = 8; keycode < 256; keycode++) {
-    // Skip if this keycode isn't valid
-    if (!xkb_keymap_key_get_name(ctx->xkb_keymap, keycode)) {
-      continue;
-    }
-
-    // Check if this key affects our modifier
-    if (xkb_keymap_mod_get_mask(ctx->xkb_keymap, mod_idx) &
-        xkb_keymap_key_get_mods_for_key(ctx->xkb_keymap, keycode)) {
-      const char *key_name = xkb_keymap_key_get_name(ctx->xkb_keymap, keycode);
-      std::cout << " Key " << key_name << " affects this modifier!"
-                << std::endl;
-    }
-  }
-}
 
 // More robust detection combining multiple checks
 static int detect_display_server() {
@@ -158,7 +137,6 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
         xkb_keymap_mod_get_index(ctx->xkb_keymap, alt_gr_names[i]);
     if (idx != XKB_MOD_INVALID) {
       std::cout << "Using AltGr name: " << alt_gr_names[i] << std::endl;
-      PrintModifierInfo(ctx, idx);
       ctx->alt_gr_mask = 1 << idx;
       break;
     }

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -166,9 +166,12 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
       }
     }
   }
-
+  if (ctx->keymap_received) {
+    // Don't fire the callback unless we've already been through this code path
+    // once.
+    that->OnNotificationReceived();
+  }
   ctx->keymap_received = true;
-  that->OnNotificationReceived();
 }
 
 static void keyboard_enter(void *data, struct wl_keyboard *keyboard,

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -12,37 +12,8 @@
 #include <unistd.h>
 #include <xkbcommon/xkbcommon.h>
 
-
-// More robust detection combining multiple checks
-static int detect_display_server() {
-  // Method 1: XDG_SESSION_TYPE - Can be most reliable when set correctly
-  const char *session_type = getenv("XDG_SESSION_TYPE");
-  if (session_type != NULL) {
-    if (strcmp(session_type, "wayland") == 0) {
-      return 1; // Wayland
-    } else if (strcmp(session_type, "x11") == 0) {
-      return 0; // X11
-    }
-    // Other values like "tty" could exist
-  }
-
-  // Method 2 & 3: Check for environment variables
-  const char *wayland_display = getenv("WAYLAND_DISPLAY");
-  const char *x_display = getenv("DISPLAY");
-
-  // Both could be set in some edge cases (X on Wayland or Wayland on X)
-  if (wayland_display && strlen(wayland_display) > 0) {
-    if (!(x_display && strlen(x_display) > 0)) {
-      return 1; // Only Wayland is set
-    }
-  } else if (x_display && strlen(x_display) > 0) {
-    return 0; // Only X11 is set
-  }
-
-  // If we get here, situation is ambiguous
-  return -1;
-}
-
+// Enumerates the various modifiers on this keyboard and tests which one brings
+// us to Level 3. This correlates to what we expect from the AltGr key.
 static size_t IndexOfLevel3Modifier(WaylandKeymapContext* ctx) {
   struct xkb_state *state = xkb_state_new(ctx->xkb_keymap);
   for (xkb_mod_index_t mod = 0; mod < xkb_keymap_num_mods(ctx->xkb_keymap); mod++) {
@@ -73,7 +44,9 @@ static size_t IndexOfLevel3Modifier(WaylandKeymapContext* ctx) {
     }
 
     if (activates_level3) {
+#ifdef DEBUG
       std::cout << "Found Level3 modifier: " << (mod_name ? mod_name : "unnamed") << " " << mod << std::endl;
+#endif
       xkb_state_unref(state);
       return mod;
     }
@@ -89,9 +62,6 @@ static size_t IndexOfLevel3Modifier(WaylandKeymapContext* ctx) {
 static void registry_global(void *data, struct wl_registry *registry,
                             uint32_t name, const char *interface,
                             uint32_t version) {
-  // auto env = (static_cast<Napi::Env*>(data));
-  // auto that = env->GetInstanceData<KeyboardLayoutManager>();
-  // auto ctx = that->waylandContext;
   auto that = (static_cast<KeyboardLayoutManager *>(data));
   auto ctx = that->waylandContext;
   if (strcmp(interface, "wl_seat") == 0) {
@@ -129,7 +99,9 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
   }
 
   char *keymap_string = (char *)mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
+#ifdef DEBUG
   std::cout << "KEYMAP STRING:" << std::endl << keymap_string << std::endl;
+#endif
   if (keymap_string == MAP_FAILED) {
     close(fd);
     return;
@@ -157,10 +129,16 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
     ctx->shift_mask = 1 << shift_idx;
   }
 
-  // Try to find AltGr (ISO Level3 Shift) - this varies by layout
-  // const char *alt_gr_names[] = {"ISO_Level3_Shift", "Mode_switch",
-  //                               "AltGr", "Alt"};
-
+  // It's surprisingly hard to find out which modifier key corresponds to
+  // AltGr. In theory, it could be defined by name — or by `ISO_Level3_Shift` —
+  // but in my testing, modifier keys are defined generically (`Mod1`, `Mod2`)
+  // and the connection to `AltGr` or `ISO_Level3_Shift` is done within the
+  // keymap definition itself
+  // (https://github.com/xkbcommon/libxkbcommon/blob/master/doc/keymap-format-text-v1.md).
+  //
+  // We know that `AltGr` is meant to bring us to keyboard level 3, so we'll
+  // try this: loop through the set of modifiers and return the first one that
+  // brings us to Level 3 for three or more separate keycodes.
   size_t alt_gr_index = IndexOfLevel3Modifier(ctx);
 
   if (alt_gr_index > 0) {
@@ -389,7 +367,6 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(Napi::Env env) {
     }
   }
 
-  std::cout << "Returning!" << std::endl;
   return result;
 }
 

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -369,7 +369,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
 
         // Build a fingerprint of key mappings for this layout
         std::string fingerprint;
-        const xkb_keycode_t test_keys[] = { 38+8, 39+8, 40+8 }; // a, s, d
+        const xkb_keycode_t test_keys[] = { 38, 39, 40 }; // a, s, d
 
         for (auto key : test_keys) {
             xkb_keysym_t sym = xkb_state_key_get_one_sym(test_state, key);
@@ -384,7 +384,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
 
     // Now get the fingerprint of the current active state
     std::string current_fingerprint;
-    const xkb_keycode_t test_keys[] = {38 + 8, 39 + 8, 40 + 8}; // a, s, d
+    const xkb_keycode_t test_keys[] = {38, 39, 40}; // a, s, d
 
     for (auto key : test_keys) {
       xkb_keysym_t sym = xkb_state_key_get_one_sym(temp_state, key);

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -53,7 +53,9 @@ static void registry_global(void *data, struct wl_registry *registry, uint32_t n
     std::cout << "Binding seat!" << std::endl;
     ctx->seat = (struct wl_seat*)wl_registry_bind(registry, name, &wl_seat_interface, 1);
     if (ctx->seat) {
+      std::cout << "Seat bound! Getting keyboard…" << std::endl;
       ctx->keyboard = wl_seat_get_keyboard(ctx->seat);
+      std::cout << "…done!" << std::endl;
     }
   }
 }

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -10,57 +10,6 @@
 #include <iostream>
 #include <locale.h>
 
-// Function to get current keyboard layout using xkbcommon
-static char* get_current_layout() {
-    // Set locale to use system defaults
-    setlocale(LC_ALL, "");
-
-    // Create xkb context
-    struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
-    if (!context) return strdup("unknown");
-
-    // Get layout from environment or default rules
-    const char *env_layout = getenv("XKB_DEFAULT_LAYOUT");
-    const char *env_rules = getenv("XKB_DEFAULT_RULES");
-    const char *env_model = getenv("XKB_DEFAULT_MODEL");
-    const char *env_variant = getenv("XKB_DEFAULT_VARIANT");
-    const char *env_options = getenv("XKB_DEFAULT_OPTIONS");
-
-    struct xkb_rule_names names = {
-        .rules = env_rules,
-        .model = env_model,
-        .layout = env_layout,
-        .variant = env_variant,
-        .options = env_options
-    };
-
-    // Create keymap from names
-    struct xkb_keymap *keymap =
-        xkb_keymap_new_from_names(context, &names, XKB_KEYMAP_COMPILE_NO_FLAGS);
-
-    // Default result
-    char *result = strdup("unknown");
-
-    if (keymap) {
-        // Get the number of layouts (groups)
-        xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(keymap);
-
-        if (num_layouts > 0) {
-            // Get the name of the first layout
-            const char *layout_name = xkb_keymap_layout_get_name(keymap, 0);
-            if (layout_name) {
-                free(result);
-                result = strdup(layout_name);
-            }
-        }
-
-        xkb_keymap_unref(keymap);
-    }
-
-    xkb_context_unref(context);
-    return result;
-}
-
 // More robust detection combining multiple checks
 static int detect_display_server() {
   // Method 1: XDG_SESSION_TYPE - Can be most reliable when set correctly
@@ -91,42 +40,148 @@ static int detect_display_server() {
   return -1;
 }
 
-static bool GetWaylandKeymap(xkb_context *context, xkb_keymap **keymap) {
-  // Try to find the keymap in the XDG runtime dir
-  const char *xdg_runtime = getenv("XDG_RUNTIME_DIR");
-  if (!xdg_runtime) {
-    std::cout << "No runtime" << std::endl;
-    return false;
+
+// REGISTRY LISTENER
+// =================
+
+static void registry_global(void *data, struct wl_registry *registry, uint32_t name, const char *interface, uint32_t version) {
+  WaylandKeymapContext *ctx = (WaylandKeymapContext *)data;
+  if (strcmp(interface, "wl_seat") == 0) {
+    ctx->seat = wl_registry_bind(registry, name, &wl_seat_interface, 1);
+    if (ctx->seat) {
+      ctx->keyboard = wl_seat_get_keyboard(ctx->seat);
+    }
+  }
+}
+
+static void registry_global_remove(void *data, struct wl_registry *registry,
+                                   uint32_t name) {
+  // Not used
+}
+
+static const struct wl_registry_listener registry_listener = {
+    registry_global, registry_global_remove};
+
+
+
+// KEYBOARD LISTENER
+// =================
+
+// Keyboard listener callbacks
+static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
+                            uint32_t format, int32_t fd, uint32_t size) {
+
+  WaylandKeymapContext *ctx = (WaylandKeymapContext *)data;
+
+  if (format != WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1) {
+    close(fd);
+    return;
   }
 
-  // Construct path to the active keymap if it exists
-  std::string keymap_path = std::string(xdg_runtime) + "/keymap";
-  FILE *f = fopen(keymap_path.c_str(), "r");
-  if (!f) {
-    std::cout << "No file" << std::endl;
-    return false;
+  char *keymap_string = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
+  if (keymap_string == MAP_FAILED) {
+    close(fd);
+    return;
   }
 
-  // Read the keymap string
-  fseek(f, 0, SEEK_END);
-  long size = ftell(f);
-  fseek(f, 0, SEEK_SET);
+  ctx.xkb_keymap = xkb_keymap_new_from_string(ctx->xkb_context, keymap_string,
+                                              XKB_KEYMAP_FORMAT_TEXT_V1,
+                                              XKB_KEYMAP_COMPILE_NO_FLAGS);
 
-  char *keymap_string = new char[size + 1];
-  fread(keymap_string, 1, size, f);
-  keymap_string[size] = '\0';
-  fclose(f);
+  munmap(keymap_string, size);
+  close(fd);
 
-  // Create keymap from the string
-  *keymap = xkb_keymap_new_from_string(context, keymap_string,
-                                       XKB_KEYMAP_FORMAT_TEXT_V1,
-                                       XKB_KEYMAP_COMPILE_NO_FLAGS);
+  if (!ctx->xkb_keymap)
+    return;
 
-  delete[] keymap_string;
-  if (*keymap == nullptr) {
-    std::cout << "Something else (mysterious)" << std::endl;
+  ctx->xkb_state = xkb_state_new(ctx->xkb_keymap);
+
+  if (!ctx->xkb_state)
+    return;
+
+  // Get shift mask
+  xkb_mod_index_t shift_idx =
+      xkb_keymap_mod_get_index(app.xkb_keymap, XKB_MOD_NAME_SHIFT);
+  if (shift_idx != XKB_MOD_INVALID) {
+    ctx->shift_mask = 1 << shift_idx;
   }
-  return (*keymap != nullptr);
+
+  // Try to find AltGr (ISO Level3 Shift) - this varies by layout
+  const char *alt_gr_names[] = {"ISO_Level3_Shift", "Mode_switch", "Alt",
+                                "AltGr"};
+
+  size_t alt_gr_length = sizeof(alt_gr_names) / sizeof(alt_gr_names[0]);
+  for (size_t i = 0; i < alt_gr_length; i++) {
+    xkb_mod_index_t idx =
+        xkb_keymap_mod_get_index(app.xkb_keymap, alt_gr_names[i]);
+    if (idx != XKB_MOD_INVALID) {
+      ctx->alt_gr_mask = 1 << idx;
+      break;
+    }
+  }
+
+  ctx->keymap_received = true;
+}
+
+static void keyboard_enter(void *data, struct wl_keyboard *keyboard,
+                           uint32_t serial, struct wl_surface *surface,
+                           struct wl_array *keys) {
+  // Not used
+}
+
+static void keyboard_leave(void *data, struct wl_keyboard *keyboard,
+                           uint32_t serial, struct wl_surface *surface) {
+  // Not used
+}
+
+static void keyboard_key(void *data, struct wl_keyboard *keyboard,
+                         uint32_t serial, uint32_t time, uint32_t key,
+                         uint32_t state) {
+  // Not used
+}
+
+static void keyboard_modifiers(void *data, struct wl_keyboard *keyboard,
+                               uint32_t serial, uint32_t mods_depressed,
+                               uint32_t mods_latched, uint32_t mods_locked,
+                               uint32_t group) {
+  // Not used
+}
+
+static void keyboard_repeat_info(void *data, struct wl_keyboard *keyboard,
+                                 int32_t rate, int32_t delay) {
+  // Not used
+}
+
+static const struct wl_keyboard_listener keyboard_listener = {
+  keyboard_keymap,
+  keyboard_enter,
+  keyboard_leave,
+  keyboard_key,
+  keyboard_modifiers,
+  keyboard_repeat_info
+};
+
+static FailOnWaylandSetup(Napi::Env env) {
+  Napi::Error::New(env, "Failed to connect to Wayland display").ThrowAsJavaScriptException();
+}
+
+static CleanupWaylandContext(WaylandKeymapContext* ctx) {
+  if (ctx->xkb_state)
+      xkb_state_unref(ctx->xkb_state);
+  if (ctx->xkb_keymap)
+      xkb_keymap_unref(ctx->xkb_keymap);
+  if (ctx.xkb_context)
+      xkb_context_unref(ctx->xkb_context);
+  if (ctx->keyboard)
+      wl_keyboard_destroy(ctx->keyboard);
+  if (ctx->seat)
+      wl_seat_destroy(ctx->seat);
+  if (ctx->registry)
+      wl_registry_destroy(ctx->registry);
+  if (ctx->display) {
+      wl_display_roundtrip(ctx->display);
+      wl_display_disconnect(ctx->display);
+  }
 }
 
 void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
@@ -134,34 +189,55 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
 
   // isWayland = detect_display_server() == 1;
   isWayland = true;
+
   if (isWayland) {
-    struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
-    struct xkb_keymap *keymap = nullptr;
-    bool gotKeymap = GetWaylandKeymap(context, &keymap);
-    if (gotKeymap) {
-      std::cout << "GOT KEYMAP!" << std::endl;
-      xkbContext = context;
-      xkbKeymap = keymap;
+
+    waylandContext = new WaylandKeymapContext();
+    memset(waylandContext, 0, sizeof(WaylandKeymapContext));
+
+    waylandContext->display = wl_display_connect(NULL);
+    if (!waylandContext->display) {
+      FailOnWaylandSetup(env);
       return;
     }
-    std::cout << "FALLBACK!" << std::endl;
-    // KeyboardMonitor* monitor = calloc(1, sizeof(KeyboardMonitor));
-    // if (!monitor) {
-    //   return;
-    // }
-    //
-    // monitor->xkb_context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
-    // if (!monitor->xkb_context) {
-    //   free(monitor);
-    //   return;
-    // }
-    //
-    // monitor->display = wl_display_connect(NULL);
-    // if (!monitor->display) {
-    //   xkb_context_unref(monitor->xkb_context);
-    //   free(monitor);
-    //   return;
-    // }
+
+    waylandContext->context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+    if (!waylandContext->context) {
+      wl_display_disconnect(waylandContext->display);
+      FailOnWaylandSetup(env);
+      return;
+    }
+
+    waylandContext->registry = wl_display_get_registry(waylandContext->display);
+    wl_registry_add_listener(waylandContext->registry, &registry_listener, NULL);
+
+    // Process registry events.
+    wl_display_roundtrip(waylandContext->display);
+
+    // If a seat was found, add a keyboard listener.
+    if (waylandContext->keyboard) {
+      wl_keyboard_add_listener(
+        waylandContext->keyboard,
+        &keyboard_listener,
+        NULL
+      );
+    } else {
+      CleanupWaylandContext(waylandContext);
+      FailOnWaylandSetup(env);
+      return;
+    }
+
+    // Wait for the keymap to be received.
+    while (!waylandContext->keymap_received) {
+      if (wl_display_dispatch(waylandContext->display) < 0) {
+        CleanupWaylandContext(waylandContext);
+        FailOnWaylandSetup(env);
+        return;
+      }
+    }
+
+    // We're good. We can exit.
+    return;
   }
 
   xDisplay = XOpenDisplay("");
@@ -242,72 +318,8 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
   Napi::Value result;
 
   if (isWayland) {
-    // Wayland
-    setlocale(LC_ALL, "");
-    struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
-    if (context) {
-      // Get layout from environment or default rules
-      const char *env_layout = getenv("XKB_DEFAULT_LAYOUT");
-      const char *env_rules = getenv("XKB_DEFAULT_RULES");
-      const char *env_model = getenv("XKB_DEFAULT_MODEL");
-      const char *env_variant = getenv("XKB_DEFAULT_VARIANT");
-      const char *env_options = getenv("XKB_DEFAULT_OPTIONS");
-
-      // std::cout << "Layout from env?" << env_layout << std::endl;
-
-      struct xkb_rule_names names = {
-        .rules = env_rules,
-        .model = env_model,
-        .layout = env_layout,
-        .variant = env_variant,
-        .options = env_options
-      };
-
-      struct xkb_keymap *keymap = xkb_keymap_new_from_names(
-        context,
-        &names,
-        XKB_KEYMAP_COMPILE_NO_FLAGS
-      );
-
-      if (!keymap) {
-        std::cout << "No keymaps!" << std::endl;
-        result = env.Null();
-      } else {
-        std::cout << "Keymaps!" << std::endl;
-        xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(keymap);
-        const char *layout_name = NULL;
-        if (num_layouts > 0) {
-          std::cout << "More than one layout: " << num_layouts << std::endl;
-          for (int i = 0; i < num_layouts; i++) {
-            std::cout << "Layout " << i << " is " << xkb_keymap_layout_get_name(keymap, i) << std::endl;
-          }
-          layout_name = xkb_keymap_layout_get_name(keymap, 0);
-
-          std::cout << "First layout name: " << layout_name << std::endl;
-
-          result = Napi::String::New(env, layout_name);
-
-          std::cout << "Done with result!" << std::endl;
-
-          // Add null checks before string construction
-          // std::string layout_str = names.layout ? std::string(names.layout) : "unknown";
-          // std::string variant_str = names.variant ? std::string(names.variant) : "";
-
-          // if (!variant_str.empty()) {
-          //   result = Napi::String::New(env, layout_str + "," + variant_str);
-          // } else {
-          //   result = Napi::String::New(env, layout_str);
-          // }
-        }
-      }
-
-      std::cout << "Unreffing…" << std::endl;
-      xkb_keymap_unref(keymap);
-      std::cout << "…unreffed!" << std::endl;
-      xkb_context_unref(context);
-    } else {
-      result = env.Null();
-    }
+    // TODO
+    return env.Null();
   } else {
     // X11
     XkbRF_VarDefsRec vdr;
@@ -441,38 +453,82 @@ Napi::Value CharacterForNativeCode(Napi::Env env, XIC xInputContext, XKeyEvent *
   }
 }
 
+static char* get_key_char(WaylandKeymapContext *ctx, uint32_t keycode, xkb_mod_mask_t modifiers) {
+  // XKB keycodes are offset by 8 from evdev keycodes.
+  xkb_keycode_t xkb_keycode = keycode + 8;
+
+  // Create a copy of the XKB state so we can apply modifiers.
+  struct xkb_state *temp_state = xkb_state_new(ctx->xkb_keymap);
+  if (!temp_state) {
+    return NULL;
+  }
+
+  xkb_state_update_mask(temp_state, modifiers, 0, 0, 0, 0, 0);
+
+  xkb_keysym_t keysym = xkb_state_key_get_one_sym(temp_state, xkb_keycode);
+
+  // Allocate memory for the result.
+  char *result = malloc(8); // Enough for any UTF-8 character.
+  if (!result) {
+    xkb_state_unref(temp_state);
+    return NULL;
+  }
+
+  // Convert keysym to UTF-8.
+  if (keysym == XKB_KEY_NoSymbol) {
+    strcpy(result, "Dead");
+  } else {
+    int len = xkb_keysym_to_utf8(keysym, result, 0);
+    if (len <= 0) {
+      // If we couldn't get a UTF-8 character, fall back to the keysym’s name.
+      xkb_keysym_get_name(keysym, result, 0);
+    }
+  }
+
+  xkb_state_unref(temp_state);
+  return result;
+}
+
+static Napi::Value WaylandCharacterForCode(Napi::Env env, WaylandKeymapContext *ctx, uint32_t keycode, xkb_mod_mask_t modifiers) {
+  char *result = get_key_char(ctx, keycode, modifiers);
+  if (result) {
+    let wrappedResult = Napi::String::New(env, result);
+    free(result);
+    return wrappedResult;
+  } else {
+    return env.Null();
+  }
+}
+
 Napi::Value KeyboardLayoutManager::GetCurrentKeymap(const Napi::CallbackInfo& info) {
   auto env = info.Env();
   Napi::Object result = Napi::Object::New(env);
   Napi::String unmodifiedKey = Napi::String::New(env, "unmodified");
   Napi::String withShiftKey = Napi::String::New(env, "withShift");
+  Napi::String withAltGraphKey = Napi::String::New(env, "withAltGraph");
+  Napi::String withAltGraphShiftKey = Napi::String::New(env, "withAltGraphShift");
 
   if (isWayland) {
-    uint keyboardBaseState = 0x0000;
-    // if (xkbState.group == 1) {
-    //   keyboardBaseState = 0x2000;
-    // } else if (xkbState.group == 2) {
-    //   keyboardBaseState = 0x4000;
-    // }
-
     size_t keyCodeMapSize = sizeof(keyCodeMap) / sizeof(keyCodeMap[0]);
     for (size_t i = 0; i < keyCodeMapSize; i++) {
       const char *dom3Code = keyCodeMap[i].dom3Code;
       uint xkbKeycode = keyCodeMap[i].xkbKeycode;
+    }
+    if (dom3Code && xkbKeycode > 0x0000) {
+      Napi::String dom3CodeKey = Napi::String::New(env, dom3Code);
+      Napi::Value unmodified = WaylandCharacterForCode(env, xkbKeycode, 0);
+      Napi::Value withShift = WaylandCharacterForCode(env, xkbKeycode, ctx->shift_mask);
+      Napi::Value withAltGraph = WaylandCharacterForCode(env, waylandContext, xkbKeycode, ctx->alt_gr_mask);
+      Napi::Value withAltGraphShift = WaylandCharacterForCode(env, waylandContext, xkbKeycode, ctx->shift_mask | ctx->alt_gr_mask);
 
-      if (dom3Code && xkbKeycode > 0x0000) {
-        Napi::String dom3CodeKey = Napi::String::New(env, dom3Code);
-        Napi::Value unmodified = CharacterForNativeCodeWayland(env, xkbContext, xkbKeymap, xkbState, xkbKeycode, keyboardBaseState);
-        Napi::Value withShift = CharacterForNativeCodeWayland(env, xkbContext, xkbKeymap, xkbState, xkbKeycode, keyboardBaseState | ShiftMask);
-
-        if (unmodified.IsString() || withShift.IsString()) {
-          Napi::Object entry = Napi::Object::New(env);
-          (entry).Set(unmodifiedKey, unmodified);
-          (entry).Set(withShiftKey, withShift);
-          (result).Set(dom3CodeKey, entry);
-        } else {
-          std::cout << "No luck for: " << dom3Code << std::endl;
-        }
+      if (unmodified.IsString() || withShift.IsString() ||
+          withAltGraph.IsString() || withAltGraphShift.IsString()) {
+        Napi::Object entry = Napi::Object::New(env);
+        (entry).Set(unmodifiedKey, unmodified);
+        (entry).Set(withShiftKey, withShift);
+        (entry).Set(withAltGraphKey, withAltGraph);
+        (entry).Set(withAltGraphShiftKey, withAltGraphShift);
+        (result).Set(dom3CodeKey, entry);
       }
     }
   } else {

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -362,7 +362,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
     // For each layout, create a test state
     for (xkb_layout_index_t layout = 0; layout < num_layouts; layout++) {
         // Create a new state with just this layout active
-        xkb_state* test_state = xkb_state_new(ctx->xkb_keymap);
+        xkb_state* test_state = xkb_state_new(waylandContext->xkb_keymap);
 
         // Set the active group (layout)
         xkb_state_update_mask(test_state, 0, 0, 0, layout, 0, 0);
@@ -387,7 +387,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
     const xkb_keycode_t test_keys[] = {38 + 8, 39 + 8, 40 + 8}; // a, s, d
 
     for (auto key : test_keys) {
-      xkb_keysym_t sym = xkb_state_key_get_one_sym(original_state, key);
+      xkb_keysym_t sym = xkb_state_key_get_one_sym(temp_state, key);
       char buf[8] = {0};
       xkb_keysym_to_utf8(sym, buf, sizeof(buf));
       current_fingerprint += buf;
@@ -395,10 +395,13 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
 
     std::cout << "Current fingerprint: " << current_fingerprint << std::endl;
 
+    xkb_state_unref(temp_state);
+    xkb_state_unref(temp_state_with_shift);
+
     // Find the matching layout
     for (xkb_layout_index_t i = 0; i < layout_fingerprints.size(); i++) {
       if (layout_fingerprints[i] == current_fingerprint) {
-        const char *name = xkb_keymap_layout_get_name(ctx->xkb_keymap, i);
+        const char *name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, i);
         return Napi::String::New(env, name ? name : std::string("layout-") + std::to_string(i));
         // name ? name : std::string("layout-") + std::to_string(i);
       }
@@ -471,8 +474,6 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
     //   first = false;
     // }
     //
-    // xkb_state_unref(temp_state);
-    // xkb_state_unref(temp_state_with_shift);
     //
     // return Napi::String::New(env, ss.str());
   } else {

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -347,70 +347,96 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
       return env.Null();
     }
 
-    // Store the current state
-    xkb_state* original_state = waylandContext->xkb_state;
+    // Get layout names - this is usually what you want for identification
+    char layout_id[256] = {0};
 
-    struct xkb_state* temp_state = xkb_state_new(waylandContext->xkb_keymap);
-    struct xkb_state* temp_state_with_shift = xkb_state_new(waylandContext->xkb_keymap);
-
-    // Get the shift mask
-    xkb_mod_index_t shift_idx = xkb_keymap_mod_get_index(waylandContext->xkb_keymap, XKB_MOD_NAME_SHIFT);
-    xkb_mod_mask_t shift_mask = 1 << shift_idx;
-
-    xkb_state_update_mask(temp_state_with_shift, shift_mask, 0, 0, 0, 0 , 0);
-
-    // Create fingerprints for each layout
-    std::vector<std::string> layout_fingerprints;
+    // Get number of layouts
     xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(waylandContext->xkb_keymap);
 
-
-    // For each layout, create a test state
-    for (xkb_layout_index_t layout = 0; layout < num_layouts; layout++) {
-        // Create a new state with just this layout active
-        xkb_state* test_state = xkb_state_new(waylandContext->xkb_keymap);
-
-        // Set the active group (layout)
-        xkb_state_update_mask(test_state, 0, 0, 0, layout, 0, 0);
-
-        // Build a fingerprint of key mappings for this layout
-        std::string fingerprint;
-        const xkb_keycode_t test_keys[] = { 38, 39, 40 }; // a, s, d
-
-        for (auto key : test_keys) {
-            xkb_keysym_t sym = xkb_state_key_get_one_sym(test_state, key);
-            char buf[8] = {0};
-            xkb_keysym_to_utf8(sym, buf, sizeof(buf));
-            fingerprint += buf;
+    // Build a string with all layout names
+    for (xkb_layout_index_t i = 0; i < num_layouts; i++) {
+      const char* layout_name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, i);
+      if (layout_name) {
+        if (i > 0) {
+          strcat(layout_id, ",");
         }
-
-        layout_fingerprints.push_back(fingerprint);
-        xkb_state_unref(test_state);
-    }
-
-    // Now get the fingerprint of the current active state
-    std::string current_fingerprint;
-    const xkb_keycode_t test_keys[] = {38, 39, 40}; // a, s, d
-
-    for (auto key : test_keys) {
-      xkb_keysym_t sym = xkb_state_key_get_one_sym(original_state, key);
-      char buf[8] = {0};
-      xkb_keysym_to_utf8(sym, buf, sizeof(buf));
-      current_fingerprint += buf;
-    }
-
-    std::cout << "Current fingerprint: " << current_fingerprint << std::endl;
-
-    xkb_state_unref(temp_state);
-    xkb_state_unref(temp_state_with_shift);
-
-    // Find the matching layout
-    for (xkb_layout_index_t i = 0; i < layout_fingerprints.size(); i++) {
-      if (layout_fingerprints[i] == current_fingerprint) {
-        const char *name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, i);
-        return Napi::String::New(env, name ? name : std::string("layout-") + std::to_string(i));
-        // name ? name : std::string("layout-") + std::to_string(i);
+        strcat(layout_id, layout_name);
       }
     }
+
+    // You could also include the active layout index
+    // xkb_layout_index_t active_layout = 0;
+    // if (ctx->xkb_state) {
+    //   active_layout = xkb_state_serialize_layout(ctx->xkb_state);
+    // }
+
+    return Napi::String::New(env, layout_id);
+
+
+    // Store the current state
+    // xkb_state* original_state = waylandContext->xkb_state;
+    //
+    // struct xkb_state* temp_state = xkb_state_new(waylandContext->xkb_keymap);
+    // struct xkb_state* temp_state_with_shift = xkb_state_new(waylandContext->xkb_keymap);
+    //
+    // // Get the shift mask
+    // xkb_mod_index_t shift_idx = xkb_keymap_mod_get_index(waylandContext->xkb_keymap, XKB_MOD_NAME_SHIFT);
+    // xkb_mod_mask_t shift_mask = 1 << shift_idx;
+    //
+    // xkb_state_update_mask(temp_state_with_shift, shift_mask, 0, 0, 0, 0 , 0);
+    //
+    // // Create fingerprints for each layout
+    // std::vector<std::string> layout_fingerprints;
+    // xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(waylandContext->xkb_keymap);
+    //
+    //
+    // // For each layout, create a test state
+    // for (xkb_layout_index_t layout = 0; layout < num_layouts; layout++) {
+    //     // Create a new state with just this layout active
+    //     xkb_state* test_state = xkb_state_new(waylandContext->xkb_keymap);
+    //
+    //     // Set the active group (layout)
+    //     xkb_state_update_mask(test_state, 0, 0, 0, layout, 0, 0);
+    //
+    //     // Build a fingerprint of key mappings for this layout
+    //     std::string fingerprint;
+    //     const xkb_keycode_t test_keys[] = { 38, 39, 40 }; // a, s, d
+    //
+    //     for (auto key : test_keys) {
+    //         xkb_keysym_t sym = xkb_state_key_get_one_sym(test_state, key);
+    //         char buf[8] = {0};
+    //         xkb_keysym_to_utf8(sym, buf, sizeof(buf));
+    //         fingerprint += buf;
+    //     }
+    //
+    //     layout_fingerprints.push_back(fingerprint);
+    //     xkb_state_unref(test_state);
+    // }
+    //
+    // // Now get the fingerprint of the current active state
+    // std::string current_fingerprint;
+    // const xkb_keycode_t test_keys[] = {38, 39, 40}; // a, s, d
+    //
+    // for (auto key : test_keys) {
+    //   xkb_keysym_t sym = xkb_state_key_get_one_sym(original_state, key);
+    //   char buf[8] = {0};
+    //   xkb_keysym_to_utf8(sym, buf, sizeof(buf));
+    //   current_fingerprint += buf;
+    // }
+    //
+    // std::cout << "Current fingerprint: " << current_fingerprint << std::endl;
+    //
+    // xkb_state_unref(temp_state);
+    // xkb_state_unref(temp_state_with_shift);
+    //
+    // // Find the matching layout
+    // for (xkb_layout_index_t i = 0; i < layout_fingerprints.size(); i++) {
+    //   if (layout_fingerprints[i] == current_fingerprint) {
+    //     const char *name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, i);
+    //     return Napi::String::New(env, name ? name : std::string("layout-") + std::to_string(i));
+    //     // name ? name : std::string("layout-") + std::to_string(i);
+    //   }
+    // }
 
     // // Keys to test - include a variety of keys from different parts of keyboard
     // const xkb_keycode_t test_keys[] = {

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -345,7 +345,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
     }
 
     xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(waylandContext->xkb_keymap);
-    xkb_layout_index_t active_layout = 0;
+    xkb_layout_index_t active_layout_index = 0;
     if (waylandContext->xkb_state) {
       active_layout_index = xkb_state_serialize_layout(waylandContext->xkb_state);
     }

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -590,11 +590,11 @@ void KeyboardLayoutManager::SetupWaylandPolling() {
   waylandPoll = new uv_poll_t;
   waylandPoll->data = this;
 
-  // uv_poll_init(uv_default_loop(), waylandPoll, fd);
-  // uv_poll_start(waylandPoll, UV_READABLE, OnWaylandEvent);
+  uv_poll_init(uv_default_loop(), waylandPoll, fd);
+  uv_poll_start(waylandPoll, UV_READABLE, OnWaylandEvent);
 
-  // Unref the handles so they don't prevent process exit
-  // uv_unref((uv_handle_t*)wayland_poll);
+  Unref the handles so they don't prevent process exit
+  uv_unref((uv_handle_t*)wayland_poll);
 
   // // Create a check handle that runs in each iteration of the event loop
   // exit_check = new uv_check_t;
@@ -639,9 +639,9 @@ void KeyboardLayoutManager::OnWaylandEvent(uv_poll_t *handle, int status,
 
 void KeyboardLayoutManager::CleanupWaylandPolling() {
   if (waylandPoll) {
-    // uv_poll_stop(waylandPoll);
-    // uv_close((uv_handle_t *)waylandPoll,
-    //          [](uv_handle_t *handle) { delete (uv_poll_t *)handle; });
+    uv_poll_stop(waylandPoll);
+    uv_close((uv_handle_t *)waylandPoll,
+             [](uv_handle_t *handle) { delete (uv_poll_t *)handle; });
     waylandPoll = nullptr;
   }
 }

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -346,6 +346,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(Napi::Env env) {
     const char *layout_name =
         xkb_keymap_layout_get_name(waylandContext->xkb_keymap, 0);
 
+    std::cout << "Current layout: " << layout_name << std::endl;
     result = Napi::String::New(env, layout_name);
   } else {
     // X11

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -187,6 +187,8 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
       const char *env_variant = getenv("XKB_DEFAULT_VARIANT");
       const char *env_options = getenv("XKB_DEFAULT_OPTIONS");
 
+      std::cout << "Layout from env?" << env_layout << std::endl;
+
       struct xkb_rule_names names = {
         .rules = env_rules,
         .model = env_model,
@@ -209,10 +211,13 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
         xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(keymap);
         const char *layout_name = NULL;
         if (num_layouts > 0) {
-          std::cout << "More than one layout!" << std::endl;
+          std::cout << "More than one layout: " << num_layouts << std::endl;
+          for (int i = 0; i < num_layouts; i++) {
+            std::cout << "Layout " << i << " is " << layout_name(xkb_keymap_layout_get_name(keymap, i)) << std::endl;
+          }
           layout_name = xkb_keymap_layout_get_name(keymap, 0);
 
-          std::cout << "Layout name: " << layout_name << std::endl;
+          std::cout << "First layout name: " << layout_name << std::endl;
 
           // Add null checks before string construction
           std::string layout_str = names.layout ? std::string(names.layout) : "unknown";

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -593,7 +593,7 @@ void KeyboardLayoutManager::SetupWaylandPolling() {
   uv_poll_init(uv_default_loop(), waylandPoll, fd);
   uv_poll_start(waylandPoll, UV_READABLE, OnWaylandEvent);
 
-  Unref the handles so they don't prevent process exit
+  // Unref the handles so they don't prevent process exit
   uv_unref((uv_handle_t*)wayland_poll);
 
   // // Create a check handle that runs in each iteration of the event loop

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -49,7 +49,7 @@ static int detect_display_server() {
 
 static void registry_global(void *data, struct wl_registry *registry, uint32_t name, const char *interface, uint32_t version) {
   auto env = (static_cast<Napi::Env*>(data));
-  auto that = env.GetInstanceData<KeyboardLayoutManager>();
+  auto that = env->GetInstanceData<KeyboardLayoutManager>();
   auto ctx = that->waylandContext;
   // WaylandKeymapContext *ctx = (static_cast<KeyboardLayoutManager *>(data))->waylandContext;
   if (strcmp(interface, "wl_seat") == 0) {
@@ -76,7 +76,7 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
                             uint32_t format, int32_t fd, uint32_t size) {
 
   auto env = (static_cast<Napi::Env*>(data));
-  auto that = env.GetInstanceData<KeyboardLayoutManager>();
+  auto that = env->GetInstanceData<KeyboardLayoutManager>();
   auto ctx = that->waylandContext;
 
   if (format != WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1) {

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -340,6 +340,9 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
   Napi::HandleScope scope(env);
   Napi::Value result;
 
+  // Store the current state
+  xkb_state* original_state = ctx->xkb_state;
+
   if (isWayland) {
     if (!waylandContext || !waylandContext->xkb_keymap || !waylandContext->xkb_state) {
       return env.Null();
@@ -387,7 +390,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
     const xkb_keycode_t test_keys[] = {38, 39, 40}; // a, s, d
 
     for (auto key : test_keys) {
-      xkb_keysym_t sym = xkb_state_key_get_one_sym(temp_state, key);
+      xkb_keysym_t sym = xkb_state_key_get_one_sym(original_state, key);
       char buf[8] = {0};
       xkb_keysym_to_utf8(sym, buf, sizeof(buf));
       current_fingerprint += buf;

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -194,7 +194,8 @@ static void CleanupWaylandContext(WaylandKeymapContext* ctx) {
 }
 
 void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
-  env = info.Env();
+  auto env = info.Env();
+  _env = env;
 
   // isWayland = detect_display_server() == 1;
   isWayland = true;
@@ -619,5 +620,5 @@ void KeyboardLayoutManager::CleanupWaylandPolling() {
 
 
 void KeyboardLayoutManager::ProcessCallbackWrapper() {
-  ProcessCallback(env, callback);
+  ProcessCallback(_env, callback);
 }

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -213,7 +213,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
         if (num_layouts > 0) {
           std::cout << "More than one layout: " << num_layouts << std::endl;
           for (int i = 0; i < num_layouts; i++) {
-            std::cout << "Layout " << i << " is " << layout_name(xkb_keymap_layout_get_name(keymap, i)) << std::endl;
+            std::cout << "Layout " << i << " is " << xkb_keymap_layout_get_name(keymap, i) << std::endl;
           }
           layout_name = xkb_keymap_layout_get_name(keymap, 0);
 

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -700,6 +700,23 @@ void KeyboardLayoutManager::CleanupWaylandPolling() {
   }
 }
 
-void KeyboardLayoutManager::ProcessCallbackWrapper() {
-  ProcessCallback(_env, callback.Value().As<Napi::Function>());
+// Runs on the main thread.
+void KeyboardLayoutManager::ProcessCallback(
+  Napi::Env env,
+  Napi::Function callback
+) {
+  auto that = env.GetInstanceData<KeyboardLayoutManager>();
+  auto current = that->GetCurrentKeyboardLayout(env);
+
+  if (current.IsString()) {
+    Napi::String str = current.As<Napi::String>();
+    std::string value = str.Utf8Value();
+    std::cout << "Sanity check: value is " << value << std::endl;
+  } else {
+    std::cout << "Sanity check: is NOT a string!";
+  }
+
+  Napi::Object global = env.Global();
+  callback.MakeCallback(global, {current.As<Napi::String>()});
+  // callback.Call({current});
 }

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -10,9 +10,9 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
-#ifdef DEBUG
 #include <iostream>
-#endif
+// #ifdef DEBUG
+// #endif
 
 // Wayland-only block begins…
 #ifdef HAS_WAYLAND
@@ -384,12 +384,14 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo &info) {
 
   waylandContext->display = wl_display_connect(NULL);
   if (!waylandContext->display) {
+    std::cout << "No display" << std::endl;
     CleanupWaylandContext(waylandContext);
     goto x11;
   }
 
   waylandContext->xkb_context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
   if (!waylandContext->xkb_context) {
+    std::cout << "No context" << std::endl;
     CleanupWaylandContext(waylandContext);
     goto x11;
   }
@@ -413,6 +415,7 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo &info) {
     wl_keyboard_add_listener(waylandContext->keyboard, &keyboard_listener,
                              this);
   } else {
+    std::cout << "No keyboard" << std::endl;
     CleanupWaylandContext(waylandContext);
     goto x11;
   }
@@ -422,6 +425,7 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo &info) {
   // TODO: Timeout?
   while (!waylandContext->keymap_received) {
     if (wl_display_dispatch(waylandContext->display) < 0) {
+      std::cout << "No keymap event" << std::endl;
       CleanupWaylandContext(waylandContext);
       goto x11;
     }

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -205,11 +205,24 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
         xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(keymap);
         const char *layout_name = NULL;
         if (num_layouts > 0) {
-          layout_name = strdup(xkb_keymap_layout_get_name(keymap, 0));
-          result = Napi::String::New(env, std::string(names.layout || "") + "," + std::string(names.variant || ""));
-        } else {
-          result = env.Null();
+          layout_name = xkb_keymap_layout_get_name(keymap, 0);
+
+          // Add null checks before string construction
+          std::string layout_str = names.layout ? std::string(names.layout) : "unknown";
+          std::string variant_str = names.variant ? std::string(names.variant) : "";
+
+          if (!variant_str.empty()) {
+            result = Napi::String::New(env, layout_str + "," + variant_str);
+          } else {
+            result = Napi::String::New(env, layout_str);
+          }
         }
+        // if (num_layouts > 0) {
+        //   layout_name = strdup(xkb_keymap_layout_get_name(keymap, 0));
+        //   result = Napi::String::New(env, std::string(names.layout) + "," + std::string(names.variant));
+        // } else {
+        //   result = env.Null();
+        // }
       }
       xkb_keymap_unref(keymap);
       xkb_context_unref(context);

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -612,13 +612,39 @@ Napi::Value CharacterForNativeCode(Napi::Env env, XIC xInputContext, XKeyEvent *
   }
 }
 
+xkb_state *copy_state_without_modifiers(WaylandKeymapContext *ctx) {
+  if (!ctx || !ctx->xkb_state || !ctx->xkb_keymap) {
+    return nullptr;
+  }
+
+  // Create a new state from the keymap
+  xkb_state *new_state = xkb_state_new(ctx->xkb_keymap);
+  if (!new_state) {
+    return nullptr;
+  }
+
+  // Get the current group/layout index
+  xkb_layout_index_t group = xkb_state_serialize_layout(ctx->xkb_state);
+
+  // Update the new state with:
+  // - No depressed modifiers (0)
+  // - No latched modifiers (0)
+  // - No locked modifiers (0)
+  // - Current layout/group index
+  // - No latched layout (0)
+  // - No locked layout (0)
+  xkb_state_update_mask(new_state, 0, 0, 0, group, 0, 0);
+
+  return new_state;
+}
+
 static char* get_key_char(WaylandKeymapContext *ctx, uint32_t keycode, xkb_mod_mask_t modifiers) {
   // At first I thought we needed to offset this by 8, but it already seems
   // correct as-is.
   xkb_keycode_t xkb_keycode = keycode;
 
   // Create a copy of the XKB state so we can apply modifiers.
-  struct xkb_state *temp_state = xkb_state_new(ctx->xkb_keymap);
+  struct xkb_state *temp_state = copy_state_without_modifiers(ctx);
   if (!temp_state) {
     return strdup("error");
   }

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -196,6 +196,7 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
     std::cout << "in PlatformSetup!" << std::endl;
     waylandContext = new WaylandKeymapContext();
     memset(waylandContext, 0, sizeof(WaylandKeymapContext));
+    std::cout << "memset!" << std::endl;
 
     waylandContext->display = wl_display_connect(NULL);
     if (!waylandContext->display) {
@@ -204,6 +205,8 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
       return;
     }
 
+    std::cout << "Got this far 00!" << std::endl;
+
     waylandContext->xkb_context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
     if (!waylandContext->xkb_context) {
       std::cout << "Oof 2!" << std::endl;
@@ -211,6 +214,8 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
       FailOnWaylandSetup(env);
       return;
     }
+
+    std::cout << "Got this far 0!" << std::endl;
 
     waylandContext->registry = wl_display_get_registry(waylandContext->display);
     wl_registry_add_listener(waylandContext->registry, &registry_listener, NULL);

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -43,6 +43,46 @@ static int detect_display_server() {
   return -1;
 }
 
+static IndexOfLevel3Modifier(WaylandKeymapContext* ctx) {
+  struct xkb_state *state = xkb_state_new(ctx->keymap);
+  for (xkb_mod_index_t mod = 0; mod < xkb_keymap_num_mods(ctx->xkb_keymap); mod++) {
+    xkb_mod_mask_t mask = 1 << mod;
+    const char *mod_name = xkb_keymap_mod_get_name(ctx->xkb_keymap, mod);
+    xkb_state_update_mask(state, mask, 0, 0, 0, 0, 0);
+
+    bool activates_level3 = false;
+    int level3_keys_count = 0;
+
+    for (xkb_keycode_t keycode = 8; keycode < 256; keycode++) {
+      if (!xkb_keymap_key_get_name(ctx->xkb_keymap, keycode)) {
+        continue;
+      }
+
+      xkb_layout_index_t group = 0;
+      xkb_level_index_t level = xkb_state_key_get_level(state, keycode, group);
+
+      if (level == 2) {
+        const char *key_name = xkb_keymap_key_get_name(ctx->xkb_keymap, keycode);
+        level3_keys_count++;
+
+        if (level3_keys_count >= 3) {
+          activates_level3 = true;
+          break;
+        }
+      }
+    }
+
+    if (activates_level3) {
+      std::cout << "Found Level3 modifier: " << (mod_name ? mod_name : "unnamed") << " " << mod << std::endl;
+      xkb_state_unref(state);
+      return mod;
+    }
+  }
+
+  xkb_state_unref(state);
+  return 0;
+}
+
 // REGISTRY LISTENER
 // =================
 
@@ -121,24 +161,30 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
   // const char *alt_gr_names[] = {"ISO_Level3_Shift", "Mode_switch",
   //                               "AltGr", "Alt"};
 
-  const char *alt_gr_names[] = {
-      "ISO_Level3_Shift", // Most common for European layouts
-      "Mode_switch",      // Often used as an alias
-      "AltGr",            // Explicit name on some layouts
-      "Mod5",             // Often mapped to AltGr
-      "Mod3",             // Sometimes used for AltGr
-      "LevelThree",       // Another name used in some layouts
-      "Right Alt"         // Sometimes used explicitly
-  };
+  size_t alt_gr_index = IndexOfLevel3Modifier(ctx);
 
-  size_t alt_gr_length = sizeof(alt_gr_names) / sizeof(alt_gr_names[0]);
-  for (size_t i = 0; i < alt_gr_length; i++) {
-    xkb_mod_index_t idx =
-        xkb_keymap_mod_get_index(ctx->xkb_keymap, alt_gr_names[i]);
-    if (idx != XKB_MOD_INVALID) {
-      std::cout << "Using AltGr name: " << alt_gr_names[i] << std::endl;
-      ctx->alt_gr_mask = 1 << idx;
-      break;
+  if (alt_gr_index > 0) {
+    ctx_alt_gr_mask = 1 << alt_gr_index;
+  } else {
+    const char *alt_gr_names[] = {
+        "ISO_Level3_Shift", // Most common for European layouts
+        "Mode_switch",      // Often used as an alias
+        "AltGr",            // Explicit name on some layouts
+        "Mod5",             // Often mapped to AltGr
+        "Mod3",             // Sometimes used for AltGr
+        "LevelThree",       // Another name used in some layouts
+        "Right Alt"         // Sometimes used explicitly
+    };
+
+    size_t alt_gr_length = sizeof(alt_gr_names) / sizeof(alt_gr_names[0]);
+    for (size_t i = 0; i < alt_gr_length; i++) {
+      xkb_mod_index_t idx =
+          xkb_keymap_mod_get_index(ctx->xkb_keymap, alt_gr_names[i]);
+      if (idx != XKB_MOD_INVALID) {
+        std::cout << "Using AltGr name: " << alt_gr_names[i] << std::endl;
+        ctx->alt_gr_mask = 1 << idx;
+        break;
+      }
     }
   }
 

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -225,7 +225,7 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
 
     waylandContext->registry = wl_display_get_registry(waylandContext->display);
     std::cout << "Listener!" << std::endl;
-    wl_registry_add_listener(waylandContext->registry, &registry_listener, NULL);
+    wl_registry_add_listener(waylandContext->registry, &registry_listener, waylandContext);
 
     // Process registry events.
     wl_display_roundtrip(waylandContext->display);

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -1,49 +1,101 @@
 #include "keyboard-layout-manager.h"
 
+#include <xkbcommon/xkbcommon.h>
 #include <X11/XKBlib.h>
 #include <X11/Xutil.h>
 #include <X11/extensions/XKBrules.h>
 #include <cwctype>
 #include <cctype>
 
+// More robust detection combining multiple checks
+static int detect_display_server() {
+  // Method 1: XDG_SESSION_TYPE - Can be most reliable when set correctly
+  const char *session_type = getenv("XDG_SESSION_TYPE");
+  if (session_type != NULL) {
+    if (strcmp(session_type, "wayland") == 0) {
+      return 1; // Wayland
+    } else if (strcmp(session_type, "x11") == 0) {
+      return 0; // X11
+    }
+    // Other values like "tty" could exist
+  }
+
+  // Method 2 & 3: Check for environment variables
+  const char *wayland_display = getenv("WAYLAND_DISPLAY");
+  const char *x_display = getenv("DISPLAY");
+
+  // Both could be set in some edge cases (X on Wayland or Wayland on X)
+  if (wayland_display && strlen(wayland_display) > 0) {
+    if (!(x_display && strlen(x_display) > 0)) {
+      return 1; // Only Wayland is set
+    }
+  } else if (x_display && strlen(x_display) > 0) {
+    return 0; // Only X11 is set
+  }
+
+  // If we get here, situation is ambiguous
+  return -1;
+}
+
 void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
   auto env = info.Env();
 
-  xDisplay = XOpenDisplay("");
-  CHECK_VOID(
-    xDisplay,
-    "Could not connect to X display",
-    env
-  );
-
-  xInputMethod = XOpenIM(xDisplay, 0, 0, 0);
-  if (!xInputMethod) return;
-
-  XIMStyles* styles = 0;
-  if (XGetIMValues(xInputMethod, XNQueryInputStyle, &styles, NULL) || !styles) {
-    return;
-  }
-
-  XIMStyle bestMatchStyle = 0;
-  for (int i = 0; i < styles->count_styles; i++) {
-    XIMStyle thisStyle = styles->supported_styles[i];
-    if (thisStyle == (XIMPreeditNothing | XIMStatusNothing))
-    {
-      bestMatchStyle = thisStyle;
-      break;
-    }
-  }
-  XFree(styles);
-  if (!bestMatchStyle) return;
-
-  Window window;
-  int revert_to;
-  XGetInputFocus(xDisplay, &window, &revert_to);
-  if (window != BadRequest) {
-    xInputContext = XCreateIC(
-      xInputMethod, XNInputStyle, bestMatchStyle, XNClientWindow, window,
-      XNFocusWindow, window, NULL
+  isWayland = detect_display_server() == 1;
+  if (isWayland) {
+    // KeyboardMonitor* monitor = calloc(1, sizeof(KeyboardMonitor));
+    // if (!monitor) {
+    //   return;
+    // }
+    //
+    // monitor->xkb_context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+    // if (!monitor->xkb_context) {
+    //   free(monitor);
+    //   return;
+    // }
+    //
+    // monitor->display = wl_display_connect(NULL);
+    // if (!monitor->display) {
+    //   xkb_context_unref(monitor->xkb_context);
+    //   free(monitor);
+    //   return;
+    // }
+  } else {
+    xDisplay = XOpenDisplay("");
+    CHECK_VOID(
+      xDisplay,
+      "Could not connect to X display",
+      env
     );
+
+    xInputMethod = XOpenIM(xDisplay, 0, 0, 0);
+    if (!xInputMethod) return;
+
+    XIMStyles* styles = 0;
+    if (XGetIMValues(xInputMethod, XNQueryInputStyle, &styles, NULL) || !styles) {
+      return;
+    }
+
+    XIMStyle bestMatchStyle = 0;
+    for (int i = 0; i < styles->count_styles; i++) {
+      XIMStyle thisStyle = styles->supported_styles[i];
+      if (thisStyle == (XIMPreeditNothing | XIMStatusNothing))
+      {
+        bestMatchStyle = thisStyle;
+        break;
+      }
+    }
+    XFree(styles);
+    if (!bestMatchStyle) return;
+
+    Window window;
+    int revert_to;
+    XGetInputFocus(xDisplay, &window, &revert_to);
+    if (window != BadRequest) {
+      xInputContext = XCreateIC(
+        xInputMethod, XNInputStyle, bestMatchStyle, XNClientWindow, window,
+        XNFocusWindow, window, NULL
+      );
+    }
   }
 }
 
@@ -68,18 +120,55 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
   Napi::HandleScope scope(env);
   Napi::Value result;
 
-  XkbRF_VarDefsRec vdr;
-  char *tmp = NULL;
-  if (XkbRF_GetNamesProp(xDisplay, &tmp, &vdr) && vdr.layout) {
-    XkbStateRec xkbState;
-    XkbGetState(xDisplay, XkbUseCoreKbd, &xkbState);
-    if (vdr.variant) {
-      result = Napi::String::New(env, std::string(vdr.layout) + "," + std::string(vdr.variant) + " [" + std::to_string(xkbState.group) + "]");
+  if (isWayland) {
+    // Wayland
+    setlocale(LC_ALL, "");
+    struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+    if (context) {
+      struct xkb_rule_names names = {
+        .rules = NULL,
+        .model = NULL,
+        .layout = NULL,
+        .variant = NULL,
+        .options = NULL
+      };
+      struct xkb_keymap *keymap = xkb_keymap_new_from_names(
+        context,
+        &names,
+        XKB_KEYMAP_COMPILE_NO_FLAGS
+      );
+      if (!keymap) {
+        result = env.Null();
+      } else {
+        xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(keymap);
+        const char *layout_name = NULL;
+        if (num_layouts > 0) {
+          layout_name = strdup(xkb_keymap_layout_get_name(keymap, 0));
+          result = Napi::String::New(env, std::string(names.layout) + "," + std::string(names.variant));
+        } else {
+          result = env.Null();
+        }
+      }
+      xkb_keymap_unref(context);
+      xkb_context_unref(context);
     } else {
-      result = Napi::String::New(env, std::string(vdr.layout) + " [" + std::to_string(xkbState.group) + "]");
+      result = env.Null();
     }
   } else {
-    result = env.Null();
+    // X11
+    XkbRF_VarDefsRec vdr;
+    char *tmp = NULL;
+    if (XkbRF_GetNamesProp(xDisplay, &tmp, &vdr) && vdr.layout) {
+      XkbStateRec xkbState;
+      XkbGetState(xDisplay, XkbUseCoreKbd, &xkbState);
+      if (vdr.variant) {
+        result = Napi::String::New(env, std::string(vdr.layout) + "," + std::string(vdr.variant) + " [" + std::to_string(xkbState.group) + "]");
+      } else {
+        result = Napi::String::New(env, std::string(vdr.layout) + " [" + std::to_string(xkbState.group) + "]");
+      }
+    } else {
+      result = env.Null();
+    }
   }
 
   return result;

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -10,9 +10,9 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
+#ifdef DEBUG
 #include <iostream>
-// #ifdef DEBUG
-// #endif
+#endif
 
 // Wayland-only block begins…
 #ifdef HAS_WAYLAND
@@ -384,14 +384,12 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo &info) {
 
   waylandContext->display = wl_display_connect(NULL);
   if (!waylandContext->display) {
-    std::cout << "No display" << std::endl;
     CleanupWaylandContext(waylandContext);
     goto x11;
   }
 
   waylandContext->xkb_context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
   if (!waylandContext->xkb_context) {
-    std::cout << "No context" << std::endl;
     CleanupWaylandContext(waylandContext);
     goto x11;
   }
@@ -415,7 +413,6 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo &info) {
     wl_keyboard_add_listener(waylandContext->keyboard, &keyboard_listener,
                              this);
   } else {
-    std::cout << "No keyboard" << std::endl;
     CleanupWaylandContext(waylandContext);
     goto x11;
   }
@@ -425,7 +422,6 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo &info) {
   // TODO: Timeout?
   while (!waylandContext->keymap_received) {
     if (wl_display_dispatch(waylandContext->display) < 0) {
-      std::cout << "No keymap event" << std::endl;
       CleanupWaylandContext(waylandContext);
       goto x11;
     }

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -94,14 +94,18 @@ static int detect_display_server() {
 static bool GetWaylandKeymap(xkb_context *context, xkb_keymap **keymap) {
   // Try to find the keymap in the XDG runtime dir
   const char *xdg_runtime = getenv("XDG_RUNTIME_DIR");
-  if (!xdg_runtime)
+  if (!xdg_runtime) {
+    std::cout << "No runtime" << std::endl;
     return false;
+  }
 
   // Construct path to the active keymap if it exists
   std::string keymap_path = std::string(xdg_runtime) + "/keymap";
   FILE *f = fopen(keymap_path.c_str(), "r");
-  if (!f)
+  if (!f) {
+    std::cout << "No file" << std::endl;
     return false;
+  }
 
   // Read the keymap string
   fseek(f, 0, SEEK_END);
@@ -119,6 +123,9 @@ static bool GetWaylandKeymap(xkb_context *context, xkb_keymap **keymap) {
                                        XKB_KEYMAP_COMPILE_NO_FLAGS);
 
   delete[] keymap_string;
+  if (*keymap == nullptr) {
+    std::cout << "Something else (mysterious)" << std::endl;
+  }
   return (*keymap != nullptr);
 }
 

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -97,6 +97,14 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
   // isWayland = detect_display_server() == 1;
   isWayland = true;
   if (isWayland) {
+    struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+    struct xkb_keymap *keymap = nullptr;
+    bool gotKeymap = GetWaylandKeymap(context, &keymap);
+    if (gotKeymap) {
+      xkbContext = context;
+      xkbKeymap = keymap;
+      return;
+    }
     // KeyboardMonitor* monitor = calloc(1, sizeof(KeyboardMonitor));
     // if (!monitor) {
     //   return;
@@ -114,47 +122,59 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
     //   free(monitor);
     //   return;
     // }
-  } else {
-    xDisplay = XOpenDisplay("");
-    CHECK_VOID(
-      xDisplay,
-      "Could not connect to X display",
-      env
+  }
+
+  xDisplay = XOpenDisplay("");
+  CHECK_VOID(
+    xDisplay,
+    "Could not connect to X display",
+    env
+  );
+
+  xInputMethod = XOpenIM(xDisplay, 0, 0, 0);
+  if (!xInputMethod) return;
+
+  XIMStyles* styles = 0;
+  if (XGetIMValues(xInputMethod, XNQueryInputStyle, &styles, NULL) || !styles) {
+    return;
+  }
+
+  XIMStyle bestMatchStyle = 0;
+  for (int i = 0; i < styles->count_styles; i++) {
+    XIMStyle thisStyle = styles->supported_styles[i];
+    if (thisStyle == (XIMPreeditNothing | XIMStatusNothing))
+    {
+      bestMatchStyle = thisStyle;
+      break;
+    }
+  }
+  XFree(styles);
+  if (!bestMatchStyle) return;
+
+  Window window;
+  int revert_to;
+  XGetInputFocus(xDisplay, &window, &revert_to);
+  if (window != BadRequest) {
+    xInputContext = XCreateIC(
+      xInputMethod, XNInputStyle, bestMatchStyle, XNClientWindow, window,
+      XNFocusWindow, window, NULL
     );
-
-    xInputMethod = XOpenIM(xDisplay, 0, 0, 0);
-    if (!xInputMethod) return;
-
-    XIMStyles* styles = 0;
-    if (XGetIMValues(xInputMethod, XNQueryInputStyle, &styles, NULL) || !styles) {
-      return;
-    }
-
-    XIMStyle bestMatchStyle = 0;
-    for (int i = 0; i < styles->count_styles; i++) {
-      XIMStyle thisStyle = styles->supported_styles[i];
-      if (thisStyle == (XIMPreeditNothing | XIMStatusNothing))
-      {
-        bestMatchStyle = thisStyle;
-        break;
-      }
-    }
-    XFree(styles);
-    if (!bestMatchStyle) return;
-
-    Window window;
-    int revert_to;
-    XGetInputFocus(xDisplay, &window, &revert_to);
-    if (window != BadRequest) {
-      xInputContext = XCreateIC(
-        xInputMethod, XNInputStyle, bestMatchStyle, XNClientWindow, window,
-        XNFocusWindow, window, NULL
-      );
-    }
   }
 }
 
 void KeyboardLayoutManager::PlatformTeardown() {
+  if (xkbState) {
+    xkb_state_unref(xkbState);
+  }
+
+  if (xkbKeymap) {
+    xkb_keymap_unref(xkbKeymap);
+  }
+
+  if (xkbContext) {
+    xkb_context_unref(xkbContext);
+  }
+
   std::cout << "Teardown!" << std::endl;
   if (xInputContext) {
     XDestroyIC(xInputContext);
@@ -291,6 +311,57 @@ struct KeycodeMapEntry {
 #include "keycode_converter_data.inc"
 
 
+Napi::Value CharacterForNativeCodeWayland(
+  Napi::Env env,
+  xkb_context xkbContext,
+  xkb_keymap xkbKeymap,
+  xkb_state xkbState
+) {
+  if (!xkbContext || !xkbKeymap || !xkbState) {
+    return env.Null();
+  }
+
+  xkb_state_update_mask(xkbState, 0, 0, 0, 0, 0, 0);
+
+  xkb_mod_mask_t mod_mask = 0;
+
+  // Map standard modifiers
+  struct {
+    uint32_t x11_mask;
+    const char* xkb_name;
+  } modifiers[] = {
+    { ShiftMask, XKB_MOD_NAME_SHIFT },
+    { LockMask, XKB_MOD_NAME_CAPS },
+    { ControlMask, XKB_MOD_NAME_CTRL },
+    { Mod1Mask, XKB_MOD_NAME_ALT },
+    // Mod5Mask is often ISO_Level3_Shift (AltGr)
+    { Mod5Mask, "iso_level3_shift" }
+  };
+
+  for (const auto &mod : modifiers) {
+    if (state & mod.x11_mask) {
+      xkb_mod_index_t mod_idx = xkb_keymap_mod_get_index(xkbKeymap, mod.xkb_name);
+      if (mod_idx != XKB_MOD_INVALID) {
+        mod_mask |= (1 << mod_idx);
+      }
+    }
+  }
+
+  xkb_state_update_mask(xkbState, mod_mask, 0, 0, 0, 0, 0);
+
+  xkb_keysym_t keysym = xkb_state_key_get_one_sym(xkbState, xkbKeycode);
+
+  char buffer[8] = {0};
+  int length = xkb_keysym_to_utf8(keysym, buffer, sizeof(buffer));
+
+  if (length > 0 && !std::iscntrl(buffer[0])) {
+    return Napi::String::New(env, std::string(buffer, length));
+  } else {
+    return env.Null();
+  }
+
+}
+
 Napi::Value CharacterForNativeCode(Napi::Env env, XIC xInputContext, XKeyEvent *keyEvent, uint xkbKeycode, uint state) {
   keyEvent->keycode = xkbKeycode;
   keyEvent->state = state;
@@ -334,41 +405,90 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeymap(const Napi::CallbackInfo& in
   Napi::String unmodifiedKey = Napi::String::New(env, "unmodified");
   Napi::String withShiftKey = Napi::String::New(env, "withShift");
 
-  // Clear cached keymap.
-  XMappingEvent eventMap = {MappingNotify, 0, false, xDisplay, 0, MappingKeyboard, 0, 0};
-  XRefreshKeyboardMapping(&eventMap);
+  if (isWayland) {
 
-  XkbStateRec xkbState;
-  XkbGetState(xDisplay, XkbUseCoreKbd, &xkbState);
-  uint keyboardBaseState = 0x0000;
-  if (xkbState.group == 1) {
-    keyboardBaseState = 0x2000;
-  } else if (xkbState.group == 2) {
-    keyboardBaseState = 0x4000;
-  }
+    const char *xdg_runtime = getenv("XDG_RUNTIME_DIR");
+    if (xdg_runtime);
 
-  // Set up an event to reuse across CharacterForNativeCode calls.
-  XEvent event;
-  memset(&event, 0, sizeof(XEvent));
-  XKeyEvent* keyEvent = &event.xkey;
-  keyEvent->display = xDisplay;
-  keyEvent->type = KeyPress;
+    // Construct path to the active keymap if it exists
+    std::string keymap_path = std::string(xdg_runtime) + "/keymap";
+    FILE *f = fopen(keymap_path.c_str(), "r");
+    if (!f) return false;
 
-  size_t keyCodeMapSize = sizeof(keyCodeMap) / sizeof(keyCodeMap[0]);
-  for (size_t i = 0; i < keyCodeMapSize; i++) {
-    const char *dom3Code = keyCodeMap[i].dom3Code;
-    uint xkbKeycode = keyCodeMap[i].xkbKeycode;
+    // Read the keymap string
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+    fseek(f, 0, SEEK_SET);
 
-    if (dom3Code && xkbKeycode > 0x0000) {
-      Napi::String dom3CodeKey = Napi::String::New(env, dom3Code);
-      Napi::Value unmodified = CharacterForNativeCode(env, xInputContext, keyEvent, xkbKeycode, keyboardBaseState);
-      Napi::Value withShift = CharacterForNativeCode(env, xInputContext, keyEvent, xkbKeycode, keyboardBaseState | ShiftMask);
 
-      if (unmodified.IsString() || withShift.IsString()) {
-        Napi::Object entry = Napi::Object::New(env);
-        (entry).Set(unmodifiedKey, unmodified);
-        (entry).Set(withShiftKey, withShift);
-        (result).Set(dom3CodeKey, entry);
+    char *keymap_string = new char[size + 1];
+    fread(keymap_string, 1, size, f);
+    keymap_string[size] = '\0';
+    fclose(f);
+
+    // Create keymap from the string
+    *keymap = xkb_keymap_new_from_string(context, keymap_string,
+                                        XKB_KEYMAP_FORMAT_TEXT_V1,
+                                        XKB_KEYMAP_COMPILE_NO_FLAGS);
+
+    delete[] keymap_string;
+    return (*keymap != nullptr);
+
+    size_t keyCodeMapSize = sizeof(keyCodeMap) / sizeof(keyCodeMap[0]);
+    for (size_t i = 0; i < keyCodeMapSizel i++) {
+      const char *dom3Code = keyCodeMap[i].dom3Code;
+      uint xkbKeyCode = keyCodeMap[i].xkbKeyCode;
+
+      if (dom3Code && xkbKeyCode > 0x0000) {
+        Napi::String dom3CodeKey = Napi::String::New(env, dom3Code);
+        Napi::Value unmodified = CharacterForNativeCodeWayland(env, xkbContext, xkbKeymap, xkbState, xjbKeycode, keyboardBaseState);
+        Napi::Value withShift = CharacterForNativeCodeWayland(env, xkbContext, xkbKeymap, xkbState, keyboardBaseState | ShiftMask);
+
+        if (unmodified.IsString() || withShift.IsString()) {
+          Napi::Object entry = Napi::Object::New(env);
+          (entry).Set(unmodifiedKey, unmodified);
+          (entry).Set(withShiftKey, withShift);
+          (result).Set(dom3CodeKey, entry);
+        }
+      }
+    }
+  } else {
+    // Clear cached keymap.
+    XMappingEvent eventMap = {MappingNotify, 0, false, xDisplay, 0, MappingKeyboard, 0, 0};
+    XRefreshKeyboardMapping(&eventMap);
+
+    XkbStateRec xkbState;
+    XkbGetState(xDisplay, XkbUseCoreKbd, &xkbState);
+    uint keyboardBaseState = 0x0000;
+    if (xkbState.group == 1) {
+      keyboardBaseState = 0x2000;
+    } else if (xkbState.group == 2) {
+      keyboardBaseState = 0x4000;
+    }
+
+    // Set up an event to reuse across CharacterForNativeCode calls.
+    XEvent event;
+    memset(&event, 0, sizeof(XEvent));
+    XKeyEvent* keyEvent = &event.xkey;
+    keyEvent->display = xDisplay;
+    keyEvent->type = KeyPress;
+
+    size_t keyCodeMapSize = sizeof(keyCodeMap) / sizeof(keyCodeMap[0]);
+    for (size_t i = 0; i < keyCodeMapSize; i++) {
+      const char *dom3Code = keyCodeMap[i].dom3Code;
+      uint xkbKeycode = keyCodeMap[i].xkbKeycode;
+
+      if (dom3Code && xkbKeycode > 0x0000) {
+        Napi::String dom3CodeKey = Napi::String::New(env, dom3Code);
+        Napi::Value unmodified = CharacterForNativeCode(env, xInputContext, keyEvent, xkbKeycode, keyboardBaseState);
+        Napi::Value withShift = CharacterForNativeCode(env, xInputContext, keyEvent, xkbKeycode, keyboardBaseState | ShiftMask);
+
+        if (unmodified.IsString() || withShift.IsString()) {
+          Napi::Object entry = Napi::Object::New(env);
+          (entry).Set(unmodifiedKey, unmodified);
+          (entry).Set(withShiftKey, withShift);
+          (result).Set(dom3CodeKey, entry);
+        }
       }
     }
   }

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -700,23 +700,23 @@ void KeyboardLayoutManager::CleanupWaylandPolling() {
   }
 }
 
-// Runs on the main thread.
-void KeyboardLayoutManager::ProcessCallback(
-  Napi::Env env,
-  Napi::Function callback
-) {
-  auto that = env.GetInstanceData<KeyboardLayoutManager>();
-  auto current = that->GetCurrentKeyboardLayout(env);
-
-  if (current.IsString()) {
-    Napi::String str = current.As<Napi::String>();
-    std::string value = str.Utf8Value();
-    std::cout << "Sanity check: value is " << value << std::endl;
-  } else {
-    std::cout << "Sanity check: is NOT a string!";
-  }
-
-  Napi::Object global = env.Global();
-  callback.MakeCallback(global, {current.As<Napi::String>()});
-  // callback.Call({current});
-}
+// // Runs on the main thread.
+// void KeyboardLayoutManager::ProcessCallback(
+//   Napi::Env env,
+//   Napi::Function callback
+// ) {
+//   auto that = env.GetInstanceData<KeyboardLayoutManager>();
+//   auto current = that->GetCurrentKeyboardLayout(env);
+//
+//   if (current.IsString()) {
+//     Napi::String str = current.As<Napi::String>();
+//     std::string value = str.Utf8Value();
+//     std::cout << "Sanity check: value is " << value << std::endl;
+//   } else {
+//     std::cout << "Sanity check: is NOT a string!";
+//   }
+//
+//   Napi::Object global = env.Global();
+//   callback.MakeCallback(global, {current.As<Napi::String>()});
+//   // callback.Call({current});
+// }

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -206,7 +206,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
         const char *layout_name = NULL;
         if (num_layouts > 0) {
           layout_name = strdup(xkb_keymap_layout_get_name(keymap, 0));
-          result = Napi::String::New(env, std::string(names.layout) + "," + std::string(names.variant));
+          result = Napi::String::New(env, std::string(names.layout || "") + "," + std::string(names.variant || ""));
         } else {
           result = env.Null();
         }

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -103,7 +103,7 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
 
   // Get shift mask
   xkb_mod_index_t shift_idx =
-      xkb_keymap_mod_get_index(app.xkb_keymap, XKB_MOD_NAME_SHIFT);
+      xkb_keymap_mod_get_index(ctx->xkb_keymap, XKB_MOD_NAME_SHIFT);
   if (shift_idx != XKB_MOD_INVALID) {
     ctx->shift_mask = 1 << shift_idx;
   }
@@ -115,7 +115,7 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
   size_t alt_gr_length = sizeof(alt_gr_names) / sizeof(alt_gr_names[0]);
   for (size_t i = 0; i < alt_gr_length; i++) {
     xkb_mod_index_t idx =
-        xkb_keymap_mod_get_index(app.xkb_keymap, alt_gr_names[i]);
+        xkb_keymap_mod_get_index(ctx->xkb_keymap, alt_gr_names[i]);
     if (idx != XKB_MOD_INVALID) {
       ctx->alt_gr_mask = 1 << idx;
       break;
@@ -163,11 +163,11 @@ static const struct wl_keyboard_listener keyboard_listener = {
   keyboard_repeat_info
 };
 
-static FailOnWaylandSetup(Napi::Env env) {
+static void FailOnWaylandSetup(Napi::Env env) {
   Napi::Error::New(env, "Failed to connect to Wayland display").ThrowAsJavaScriptException();
 }
 
-static CleanupWaylandContext(WaylandKeymapContext* ctx) {
+static void CleanupWaylandContext(WaylandKeymapContext* ctx) {
   if (ctx->xkb_state)
       xkb_state_unref(ctx->xkb_state);
   if (ctx->xkb_keymap)
@@ -203,8 +203,8 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
       return;
     }
 
-    waylandContext->context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
-    if (!waylandContext->context) {
+    waylandContext->xkb_context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+    if (!waylandContext->xkb_context) {
       wl_display_disconnect(waylandContext->display);
       FailOnWaylandSetup(env);
       return;
@@ -470,9 +470,10 @@ static char* get_key_char(WaylandKeymapContext *ctx, uint32_t keycode, xkb_mod_m
   xkb_keysym_t keysym = xkb_state_key_get_one_sym(temp_state, xkb_keycode);
 
   // Allocate memory for the result.
-  char *result = malloc(8); // Enough for any UTF-8 character.
+  char *result = new char[8]; // And remember to use delete[] instead of free
   if (!result) {
     xkb_state_unref(temp_state);
+    delete[] result;
     return NULL;
   }
 
@@ -494,8 +495,8 @@ static char* get_key_char(WaylandKeymapContext *ctx, uint32_t keycode, xkb_mod_m
 static Napi::Value WaylandCharacterForCode(Napi::Env env, WaylandKeymapContext *ctx, uint32_t keycode, xkb_mod_mask_t modifiers) {
   char *result = get_key_char(ctx, keycode, modifiers);
   if (result) {
-    let wrappedResult = Napi::String::New(env, result);
-    free(result);
+    auto wrappedResult = Napi::String::New(env, result);
+    delete[] result;
     return wrappedResult;
   } else {
     return env.Null();

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -12,6 +12,28 @@
 #include <unistd.h>
 #include <xkbcommon/xkbcommon.h>
 
+static void PrintModifierInfo(WaylandKeymapContext *ctx,
+                              xkb_mod_index_t mod_idx) {
+  const char* mod_name = xkb_keymap_mod_get_name(ctx->xkb_keymap, mod_idx);
+  std::cout << "Mod name: " << mod_name << std::endl;
+
+  // List which keys are mapped to this modifier
+  for (xkb_keycode_t keycode = 8; keycode < 256; keycode++) {
+    // Skip if this keycode isn't valid
+    if (!xkb_keymap_key_get_name(ctx->xkb_keymap, keycode)) {
+      continue;
+    }
+
+    // Check if this key affects our modifier
+    if (xkb_keymap_mod_get_mask(ctx->xkb_keymap, mod_idx) &
+        xkb_keymap_key_get_mods_for_key(ctx->xkb_keymap, keycode)) {
+      const char *key_name = xkb_keymap_key_get_name(ctx->xkb_keymap, keycode);
+      std::cout << " Key " << key_name << " affects this modifier!"
+                << std::endl;
+    }
+  }
+}
+
 // More robust detection combining multiple checks
 static int detect_display_server() {
   // Method 1: XDG_SESSION_TYPE - Can be most reliable when set correctly
@@ -88,6 +110,7 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
   }
 
   char *keymap_string = (char *)mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
+  std::cout << "KEYMAP STRING:" << std::endl << keymap_string << std::endl;
   if (keymap_string == MAP_FAILED) {
     close(fd);
     return;
@@ -178,27 +201,6 @@ static void keyboard_repeat_info(void *data, struct wl_keyboard *keyboard,
 static const struct wl_keyboard_listener keyboard_listener = {
     keyboard_keymap, keyboard_enter,     keyboard_leave,
     keyboard_key,    keyboard_modifiers, keyboard_repeat_info};
-
-static void PrintModifierInfo(WaylandKeymapContext* ctx, xkb_mod_index_t mod_idx) {
-  const char mod_name = xkb_keymap_mod_get_name(ctx->xkb_keymap, mod_idx);
-  std::cout << "Mod name: " << mod_name << std::endl;
-
-  // List which keys are mapped to this modifier
-  for (xkb_keycode_t keycode = 8; keycode < 256; keycode++) {
-      // Skip if this keycode isn't valid
-      if (!xkb_keymap_key_get_name(ctx->xkb_keymap, keycode)) {
-          continue;
-      }
-
-      // Check if this key affects our modifier
-      if (xkb_keymap_mod_get_mask(ctx->xkb_keymap, mod_idx) &
-          xkb_keymap_key_get_mods_for_key(ctx->xkb_keymap, keycode)) {
-          const char* key_name = xkb_keymap_key_get_name(ctx->xkb_keymap, keycode);
-          std::cout << " Key " << key_name << " affects this modifier!" << std::endl;
-      }
-  }
-
-}
 
 static void FailOnWaylandSetup(Napi::Env env) {
   Napi::Error::New(env, "Failed to connect to Wayland display")

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -340,13 +340,13 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
   Napi::HandleScope scope(env);
   Napi::Value result;
 
-  // Store the current state
-  xkb_state* original_state = ctx->xkb_state;
-
   if (isWayland) {
     if (!waylandContext || !waylandContext->xkb_keymap || !waylandContext->xkb_state) {
       return env.Null();
     }
+
+    // Store the current state
+    xkb_state* original_state = waylandContext->xkb_state;
 
     struct xkb_state* temp_state = xkb_state_new(waylandContext->xkb_keymap);
     struct xkb_state* temp_state_with_shift = xkb_state_new(waylandContext->xkb_keymap);

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -681,7 +681,7 @@ void KeyboardLayoutManager::OnWaylandEvent(uv_poll_t *handle, int status,
     // Now read events (shouldn't block since we've been notified data is
     // available)
     if (wl_display_read_events(instance->waylandContext->display) < 0) {
-      std::cout << "ERROR Reading events…" << strerr(errno) << std::endl;
+      std::cout << "ERROR Reading events…" << strerror(errno) << std::endl;
       return;
     }
     // Dispatch the events we just read

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -357,11 +357,11 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
       return env.Null();
     }
 
-    struct xkb_state* temp_state = xkb_state_new(ctx->xkb_keymap);
-    struct xkb_state* temp_state_with_shift = xkb_state_new(ctx->xkb_keymap);
+    struct xkb_state* temp_state = xkb_state_new(waylandContext->xkb_keymap);
+    struct xkb_state* temp_state_with_shift = xkb_state_new(waylandContext->xkb_keymap);
 
     // Get the shift mask
-    xkb_mod_index_t shift_idx = xkb_keymap_mod_get_index(ctx->xkb_keymap, XKB_MOD_NAME_SHIFT);
+    xkb_mod_index_t shift_idx = xkb_keymap_mod_get_index(waylandContext->xkb_keymap, XKB_MOD_NAME_SHIFT);
     xkb_mod_mask_t shift_mask = 1 << shift_idx;
 
     xkb_state_update_mask(temp_state_with_shift, shift_mask, 0, 0, 0, 0 , 0);

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -92,7 +92,8 @@ static int detect_display_server() {
 void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
   auto env = info.Env();
 
-  isWayland = detect_display_server() == 1;
+  // isWayland = detect_display_server() == 1;
+  isWayland = true;
   if (isWayland) {
     // KeyboardMonitor* monitor = calloc(1, sizeof(KeyboardMonitor));
     // if (!monitor) {

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -371,7 +371,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
       57 + 8, // space
       28 + 8, // t
       29 + 8, // y
-      52 + 8, // dollar sign ($)
+      51 + 8, // hash/pound sign (#)
     };
 
     // Count how many times each layout index responds

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -344,20 +344,76 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
       return env.Null();
     }
 
-    xkb_layout_index_t active_layout = xkb_state_get_layout(waylandContext->xkb_state, XKB_STATE_LAYOUT_EFFECTIVE);
+    // xkb_layout_index_t active_layout = xkb_state_key_get_layout(waylandContext->xkb_state, XKB_STATE_LAYOUT_EFFECTIVE);
+    //
+    // const char* active_layout_name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, group);
+    //
+    // if (active_layout_name) {
+    //   return Napi::String::New(env, active_layout_name);
+    // }
 
-    const char* active_layout_name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, group);
+    // Keys to test - include a variety of keys from different parts of keyboard
+    const xkb_keycode_t test_keys[] = {
+      38 + 8, // a
+      39 + 8, // s
+      40 + 8, // d
+      41 + 8, // f
+      44 + 8, // j
+      45 + 8, // k
+      46 + 8, // l
+      24 + 8, // q
+      25 + 8, // w
+      30 + 8, // u
+      31 + 8, // i
+      32 + 8, // o
+      33 + 8, // p
+      57 + 8, // space
+      28 + 8, // t
+      29 + 8, // y
+    };
 
-    if (active_layout_name) {
-      return Napi::String::New(env, active_layout_name);
+    // Count how many times each layout index responds
+    std::unordered_map<xkb_layout_index_t, int> layout_scores;
+
+    // Get number of layouts
+    xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(waylandContext->xkb_keymap);
+
+    for (auto key : test_keys) {
+      xkb_layout_index_t layout_index_for_key = xkb_state_key_get_layout(waylandContext->xkb_state, key);
+      if (layout < num_layouts) {
+        layout_scores[layout_index_for_key]++;
+      }
     }
 
-    // // Get layout names - this is usually what you want for identification
-    // char layout_id[256] = {0};
-    //
-    // // Get number of layouts
-    // xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(waylandContext->xkb_keymap);
-    //
+    std::vector<std::pair<xkb_layout_index_t, int>> score_pairs;
+    for (const auto &pair : layout_scores) {
+      score_pairs.push_back(pair);
+    }
+
+    // Sort by score (descending)
+    std::sort(score_pairs.begin(), score_pairs.end(),
+              [](const auto &a, const auto &b) { return a.second > b.second; });
+
+    // Get number of layouts
+    xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(waylandContext->xkb_keymap);
+
+    std::stringstream ss;
+    bool first = true;
+
+    for (const auto &pair : score_pairs) {
+      xkb_layout_index_t idx = pair.first;
+      int score = pair.second;
+
+      const char* name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, idx);
+      std::string layout_name = name ? name : std::string("layout-") + std::to_string(idx);
+
+      if (!first) {
+        ss << ", ";
+      }
+      ss << layout_name;
+      first = false;
+    }
+
     // // Build a string with all layout names
     // for (xkb_layout_index_t i = 0; i < num_layouts; i++) {
     //   const char* layout_name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, i);
@@ -368,8 +424,8 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
     //     strcat(layout_id, layout_name);
     //   }
     // }
-    //
-    // return Napi::String::New(env, layout_id);
+    
+    return Napi::String::New(env, ss.str());
   } else {
     // X11
     XkbRF_VarDefsRec vdr;

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -619,11 +619,6 @@ void KeyboardLayoutManager::SetupWaylandPolling() {
   //
 }
 
-// Call this when the JavaScript side indicates it's okay to exit
-void KeyboardLayoutManager::AllowExit() {
-  allow_exit = true;
-}
-
 void KeyboardLayoutManager::OnWaylandEvent(uv_poll_t *handle, int status,
                                            int events) {
   KeyboardLayoutManager *instance =

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -56,6 +56,8 @@ static void registry_global(void *data, struct wl_registry *registry, uint32_t n
       std::cout << "Seat bound! Getting keyboard…" << std::endl;
       ctx->keyboard = wl_seat_get_keyboard(ctx->seat);
       std::cout << "…done!" << std::endl;
+    } else {
+      std::cout << "Failed!" << std::endl;
     }
   }
 }

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -14,8 +14,11 @@
 #include <iostream>
 #endif
 
+// Wayland-only block begins…
 #ifdef HAS_WAYLAND
+
 #include <optional>
+
 // Enumerates the various modifiers on this keyboard and tests which one brings
 // us to Level 3. This correlates to what we expect from the AltGr key.
 static std::optional<size_t> IndexOfLevel3Modifier(WaylandKeymapContext* ctx) {
@@ -98,11 +101,7 @@ static const struct wl_registry_listener registry_listener = {
 // Keyboard listener callbacks
 static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
                             uint32_t format, int32_t fd, uint32_t size) {
-
-  // auto env = (static_cast<Napi::Env*>(data));
-  // auto that = env->GetInstanceData<KeyboardLayoutManager>();
-  auto that = (static_cast<KeyboardLayoutManager *>(data));
-  auto ctx = that->waylandContext;
+  auto ctx = (static_cast<KeyboardLayoutManager *>(data))->waylandContext;
 
   if (format != WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1) {
     close(fd);
@@ -110,9 +109,11 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
   }
 
   char *keymap_string = (char *)mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
+
 #ifdef DEBUG
   std::cout << "KEYMAP STRING:" << std::endl << keymap_string << std::endl;
 #endif
+
   if (keymap_string == MAP_FAILED) {
     close(fd);
     return;
@@ -163,13 +164,13 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
     // produces the expected result, so it's more speculative than the first
     // approach.
     const char *alt_gr_names[] = {
-        "ISO_Level3_Shift", // Most common for European layouts
-        "Mode_switch",      // Often used as an alias
-        "AltGr",            // Explicit name on some layouts
-        "Mod5",             // Often mapped to AltGr
-        "Mod3",             // Sometimes used for AltGr
-        "LevelThree",       // Another name used in some layouts
-        "Right Alt"         // Sometimes used explicitly
+      "ISO_Level3_Shift", // Most common for European layouts
+      "Mode_switch",      // Often used as an alias
+      "AltGr",            // Explicit name on some layouts
+      "Mod5",             // Often mapped to AltGr
+      "Mod3",             // Sometimes used for AltGr
+      "LevelThree",       // Another name used in some layouts
+      "Right Alt"         // Sometimes used explicitly
     };
 
     size_t alt_gr_length = sizeof(alt_gr_names) / sizeof(alt_gr_names[0]);
@@ -193,7 +194,8 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
   ctx->keymap_received = true;
 }
 
-// `wayland-client` requires that we
+// `wayland-client` requires that we provide a whole bundle of listeners, even
+// though we don't really need the rest of these.
 static void keyboard_enter(void *data, struct wl_keyboard *keyboard,
                            uint32_t serial, struct wl_surface *surface,
                            struct wl_array *keys) {
@@ -249,7 +251,7 @@ static void CleanupWaylandContext(WaylandKeymapContext *ctx) {
 // Given a Wayland context, a keycode, and a modifier mask, return the
 // character that would be produced by that keycode.
 static char *GetCharForKeycode(WaylandKeymapContext *ctx, uint32_t keycode,
-                          xkb_mod_mask_t modifiers) {
+                               xkb_mod_mask_t modifiers) {
   // At first I thought we needed to offset this by 8, but it already seems
   // correct as-is.
   xkb_keycode_t xkb_keycode = keycode;
@@ -341,14 +343,14 @@ void KeyboardLayoutManager::OnWaylandEvent(uv_poll_t *handle, int status,
       wl_display_dispatch_pending(instance->waylandContext->display);
     }
     // Now read events (shouldn't block since we've been notified data is
-    // available)
+    // available).
     if (wl_display_read_events(instance->waylandContext->display) < 0) {
 #ifdef DEBUG
-    std::cout << "ERROR Reading events…" << strerror(errno) << std::endl;
+    std::cout << "Error reading events…" << strerror(errno) << std::endl;
 #endif
       return;
     }
-    // Dispatch the events we just read
+    // Dispatch the events we just read.
 #ifdef DEBUG
     std::cout << "Dispatching pending events…" << std::endl;
 #endif
@@ -365,7 +367,7 @@ void KeyboardLayoutManager::CleanupWaylandPolling() {
   }
 }
 
-#endif
+#endif // HAS_WAYLAND
 
 void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo &info) {
   auto env = info.Env();
@@ -430,7 +432,7 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo &info) {
   SetupWaylandPolling();
   return;
 
-#endif
+#endif // HAS_WAYLAND
 
 x11:
   isWayland = false;
@@ -501,7 +503,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(
     std::cout << "Current layout: " << layout_name << std::endl;
 #endif
     result = Napi::String::New(env, layout_name);
-#endif
+#endif // HAS_WAYLAND
   } else {
     // X11
     XkbRF_VarDefsRec vdr;
@@ -597,6 +599,7 @@ KeyboardLayoutManager::GetCurrentKeymap(const Napi::CallbackInfo &info) {
       Napi::String::New(env, "withAltGraphShift");
 
   if (isWayland) {
+
 #ifdef HAS_WAYLAND
     size_t keyCodeMapSize = sizeof(keyCodeMap) / sizeof(keyCodeMap[0]);
     for (size_t i = 0; i < keyCodeMapSize; i++) {
@@ -625,7 +628,8 @@ KeyboardLayoutManager::GetCurrentKeymap(const Napi::CallbackInfo &info) {
         }
       }
     }
-#endif
+#endif // HAS_WAYLAND
+
   } else {
     // Clear cached keymap.
     XMappingEvent eventMap = {MappingNotify,   0, false, xDisplay, 0,

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -335,6 +335,18 @@ void KeyboardLayoutManager::PlatformTeardown() {
 void KeyboardLayoutManager::HandleKeyboardLayoutChanged() {
 }
 
+static KeyboardStateWithShift(WaylandKeymapContext* ctx) {
+  // Create a temporary state
+  struct xkb_state* temp_state = xkb_state_new(ctx->xkb_keymap);
+  if (!temp_state) {
+    return 0; // Default to layout 0 on error
+  }
+
+  // Get the shift mask
+  xkb_mod_index_t shift_idx = xkb_keymap_mod_get_index(ctx->xkb_keymap, XKB_MOD_NAME_SHIFT);
+  xkb_mod_mask_t shift_mask = 1 << shift_idx;
+}
+
 Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::CallbackInfo& info) {
   auto env = info.Env();
   Napi::HandleScope scope(env);
@@ -344,6 +356,15 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
     if (!waylandContext || !waylandContext->xkb_keymap || !waylandContext->xkb_state) {
       return env.Null();
     }
+
+    struct xkb_state* temp_state = xkb_state_new(ctx->xkb_keymap);
+    struct xkb_state* temp_state_with_shift = xkb_state_new(ctx->xkb_keymap);
+
+    // Get the shift mask
+    xkb_mod_index_t shift_idx = xkb_keymap_mod_get_index(ctx->xkb_keymap, XKB_MOD_NAME_SHIFT);
+    xkb_mod_mask_t shift_mask = 1 << shift_idx;
+
+    xkb_state_update_mask(temp_state_with_shift, shift_mask, 0, 0, 0, 0 , 0);
 
     // xkb_layout_index_t active_layout = xkb_state_key_get_layout(waylandContext->xkb_state, XKB_STATE_LAYOUT_EFFECTIVE);
     //
@@ -381,7 +402,12 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
     xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(waylandContext->xkb_keymap);
 
     for (auto key : test_keys) {
-      xkb_layout_index_t layout_index_for_key = xkb_state_key_get_layout(waylandContext->xkb_state, key);
+      xkb_layout_index_t layout_index_for_key;
+      if (test_key === 59) {
+        layout_index_for_key = xkb_state_key_get_layout(temp_state_with_shift, key);
+      } else  {
+        layout_index_for_key = xkb_state_key_get_layout(temp_state, key);
+      }
       if (layout_index_for_key < num_layouts) {
         layout_scores[layout_index_for_key]++;
       }
@@ -415,16 +441,8 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
       first = false;
     }
 
-    // // Build a string with all layout names
-    // for (xkb_layout_index_t i = 0; i < num_layouts; i++) {
-    //   const char* layout_name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, i);
-    //   if (layout_name) {
-    //     if (i > 0) {
-    //       strcat(layout_id, ",");
-    //     }
-    //     strcat(layout_id, layout_name);
-    //   }
-    // }
+    xkb_state_unref(temp_state);
+    xkb_state_unref(temp_state_with_shift);
 
     return Napi::String::New(env, ss.str());
   } else {

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -228,11 +228,6 @@ static const struct wl_keyboard_listener keyboard_listener = {
     keyboard_keymap, keyboard_enter,     keyboard_leave,
     keyboard_key,    keyboard_modifiers, keyboard_repeat_info};
 
-static void FailOnWaylandSetup(Napi::Env env) {
-  Napi::Error::New(env, "Failed to connect to Wayland display")
-      .ThrowAsJavaScriptException();
-}
-
 static void CleanupWaylandContext(WaylandKeymapContext *ctx) {
   if (ctx->xkb_state)
     xkb_state_unref(ctx->xkb_state);

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -347,31 +347,36 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
       return env.Null();
     }
 
+    const char* layout_name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, 0);
+
+    result = Napi::String::New(env, layout_name);
+
+
     // Get layout names - this is usually what you want for identification
-    char layout_id[256] = {0};
-
-    // Get number of layouts
-    xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(waylandContext->xkb_keymap);
-
-    // Build a string with all layout names
-    for (xkb_layout_index_t i = 0; i < num_layouts; i++) {
-      const char* layout_name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, i);
-      std::cout << "Layout " << i << " is " << layout_name << std::endl;
-      if (layout_name) {
-        if (i > 0) {
-          strcat(layout_id, ",");
-        }
-        strcat(layout_id, layout_name);
-      }
-    }
-
-    // You could also include the active layout index
-    // xkb_layout_index_t active_layout = 0;
-    // if (ctx->xkb_state) {
-    //   active_layout = xkb_state_serialize_layout(ctx->xkb_state);
+    // char layout_id[256] = {0};
+    //
+    // // Get number of layouts
+    // xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(waylandContext->xkb_keymap);
+    //
+    // // Build a string with all layout names
+    // for (xkb_layout_index_t i = 0; i < num_layouts; i++) {
+    //   const char* layout_name = xkb_keymap_layout_get_name(waylandContext->xkb_keymap, i);
+    //   std::cout << "Layout " << i << " is " << layout_name << std::endl;
+    //   if (layout_name) {
+    //     if (i > 0) {
+    //       strcat(layout_id, ",");
+    //     }
+    //     strcat(layout_id, layout_name);
+    //   }
     // }
-
-    return Napi::String::New(env, layout_id);
+    //
+    // // You could also include the active layout index
+    // // xkb_layout_index_t active_layout = 0;
+    // // if (ctx->xkb_state) {
+    // //   active_layout = xkb_state_serialize_layout(ctx->xkb_state);
+    // // }
+    //
+    // return Napi::String::New(env, layout_id);
 
 
     // Store the current state

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -210,7 +210,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::Callback
           result = env.Null();
         }
       }
-      xkb_keymap_unref(context);
+      xkb_keymap_unref(keymap);
       xkb_context_unref(context);
     } else {
       result = env.Null();

--- a/src/keyboard-layout-manager-mac.mm
+++ b/src/keyboard-layout-manager-mac.mm
@@ -46,10 +46,6 @@ void KeyboardLayoutManager::PlatformSetup(const Napi::CallbackInfo& info) {
   );
 }
 
-void KeyboardLayoutManager::HandleKeyboardLayoutChanged() {
-  // no-op
-}
-
 Napi::Value KeyboardLayoutManager::GetInstalledKeyboardLanguages(const Napi::CallbackInfo& info) {
   auto env = info.Env();
   Napi::HandleScope scope(env);
@@ -103,7 +99,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLanguage(const Napi::Callba
 }
 
 Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::CallbackInfo& info) {
-  return GetCurrentKeyboardLayout(info.Env());
+return GetCurrentKeyboardLayout(info.Env());
 }
 
 Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(Napi::Env env) {

--- a/src/keyboard-layout-manager-mac.mm
+++ b/src/keyboard-layout-manager-mac.mm
@@ -99,10 +99,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLanguage(const Napi::Callba
 }
 
 Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::CallbackInfo& info) {
-return GetCurrentKeyboardLayout(info.Env());
-}
-
-Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(Napi::Env env) {
+  auto env = info.Env();
   TISInputSourceRef source = TISCopyCurrentKeyboardInputSource();
   CFStringRef sourceId = (CFStringRef) TISGetInputSourceProperty(source, kTISPropertyInputSourceID);
   return Napi::String::New(env, [(NSString *)sourceId UTF8String]);

--- a/src/keyboard-layout-manager-windows.cc
+++ b/src/keyboard-layout-manager-windows.cc
@@ -168,12 +168,9 @@ Napi::Value CharacterForNativeCode(
     if (utf8Len == 0) {
       return env.Null();
     }
-    char utf8[utf8Len];
-    WideCharToMultiByte(CP_UTF8, 0, characters, count, utf8, utf8Len, NULL, NULL);
-    return Napi::String::New(
-      env,
-      std::string(utf8, utf8Len)
-    );
+    std::string utf8(utf8Len, '\0');
+    WideCharToMultiByte(CP_UTF8, 0, characters, count, &utf8[0], utf8Len, NULL, NULL);
+    return Napi::String::New(env, utf8);
   } else {
     return env.Null();
   }
@@ -201,7 +198,7 @@ Napi::Value KeyboardLayoutManager::GetCurrentKeymap(const Napi::CallbackInfo& in
       // characters.
       if ((MapVirtualKeyEx(keyCode, MAPVK_VK_TO_CHAR, keyboardLayout) >> (sizeof(UINT) * 8 - 1))) continue;
 
-      Napi::String dom3CodeKey = Napi::New(env, dom3Code);
+      Napi::String dom3CodeKey = Napi::String::New(env, dom3Code);
       Napi::Value unmodified = CharacterForNativeCode(env, keyboardLayout, keyCode, scanCode, keyboardState, false, false);
       Napi::Value withShift = CharacterForNativeCode(env, keyboardLayout, keyCode, scanCode, keyboardState, true, false);
       Napi::Value withAltGraph = CharacterForNativeCode(env, keyboardLayout, keyCode, scanCode, keyboardState, false, true);

--- a/src/keyboard-layout-manager-windows.cc
+++ b/src/keyboard-layout-manager-windows.cc
@@ -15,19 +15,19 @@
 using namespace Napi;
 
 std::string ToUTF8(const std::wstring& string) {
-  if (string.Length() < 1) {
+  if (string.length() < 1) {
     return std::string();
   }
 
   // NB: In the pathological case, each character could expand up
   // to 4 bytes in UTF8.
-  int cbLen = (string.Length()+1) * sizeof(char) * 4;
+  int cbLen = (string.length()+1) * sizeof(char) * 4;
   char* buf = new char[cbLen];
   int retLen = WideCharToMultiByte(
     CP_UTF8,
     0,
     string.c_str(),
-    string.Length(),
+    -1,
     buf,
     cbLen,
     NULL,

--- a/src/keyboard-layout-manager-windows.cc
+++ b/src/keyboard-layout-manager-windows.cc
@@ -50,12 +50,8 @@ HKL GetForegroundWindowHKL() {
 }
 
 Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::CallbackInfo& info) {
-  return GetCurrentKeyboardLayout(info.Env());
-}
-
-
-Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(Napi::Env env) {
   Napi::HandleScope scope(env);
+  auto env = info.Env();
 
   ActivateKeyboardLayout(GetForegroundWindowHKL(), 0);
   char layoutName[KL_NAMELENGTH];

--- a/src/keyboard-layout-manager-windows.cc
+++ b/src/keyboard-layout-manager-windows.cc
@@ -49,10 +49,6 @@ HKL GetForegroundWindowHKL() {
   return GetKeyboardLayout(dwThreadId);
 }
 
-void KeyboardLayoutManager::HandleKeyboardLayoutChanged() {
-  // no-op
-}
-
 Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::CallbackInfo& info) {
   return GetCurrentKeyboardLayout(info.Env());
 }

--- a/src/keyboard-layout-manager-windows.cc
+++ b/src/keyboard-layout-manager-windows.cc
@@ -50,8 +50,8 @@ HKL GetForegroundWindowHKL() {
 }
 
 Napi::Value KeyboardLayoutManager::GetCurrentKeyboardLayout(const Napi::CallbackInfo& info) {
-  Napi::HandleScope scope(env);
   auto env = info.Env();
+  Napi::HandleScope scope(env);
 
   ActivateKeyboardLayout(GetForegroundWindowHKL(), 0);
   char layoutName[KL_NAMELENGTH];

--- a/src/keyboard-layout-manager.cc
+++ b/src/keyboard-layout-manager.cc
@@ -1,35 +1,89 @@
 #include "keyboard-layout-manager.h"
-
-using namespace v8;
-
-NAN_MODULE_INIT(init) {
-  Nan::HandleScope scope;
-  Local<FunctionTemplate> newTemplate = Nan::New<FunctionTemplate>(KeyboardLayoutManager::New);
-  newTemplate->SetClassName(Nan::New<String>("KeyboardLayoutManager").ToLocalChecked());
-  newTemplate->InstanceTemplate()->SetInternalFieldCount(1);
-
-  Local<ObjectTemplate> proto = newTemplate->PrototypeTemplate();
-
-  Nan::SetMethod(proto, "getCurrentKeyboardLayout", KeyboardLayoutManager::GetCurrentKeyboardLayout);
-  Nan::SetMethod(proto, "getCurrentKeyboardLanguage", KeyboardLayoutManager::GetCurrentKeyboardLanguage);
-  Nan::SetMethod(proto, "getInstalledKeyboardLanguages", KeyboardLayoutManager::GetInstalledKeyboardLanguages);
-  Nan::SetMethod(proto, "getCurrentKeymap", KeyboardLayoutManager::GetCurrentKeymap);
-
-  Nan::Set(target, Nan::New("KeyboardLayoutManager").ToLocalChecked(), Nan::GetFunction(newTemplate).ToLocalChecked());
-}
-
-#if NODE_MAJOR_VERSION >= 10
-NAN_MODULE_WORKER_ENABLED(keyboard_layout_manager, init)
-#else
-NODE_MODULE(keyboard_layout_manager, init)
+#ifdef DEBUG
+#include <iostream>
 #endif
 
-NAN_METHOD(KeyboardLayoutManager::New) {
-  Nan::HandleScope scope;
-  Local<Function> callbackHandle = info[0].As<Function>();
-  Nan::Callback *callback = new Nan::Callback(callbackHandle);
+KeyboardLayoutManager::KeyboardLayoutManager(const Napi::CallbackInfo& info):
+ Napi::ObjectWrap<KeyboardLayoutManager>(info) {
+  #if defined(__linux__) || defined(__FreeBSD__)
+    xInputContext = nullptr;
+    xInputMethod = nullptr;
+  #endif
 
-  KeyboardLayoutManager *manager = new KeyboardLayoutManager(info.GetIsolate(), callback);
-  manager->Wrap(info.This());
-  return;
+  auto env = info.Env();
+  CHECK_VOID(
+    info[0].IsFunction(),
+    "Expected function as first argument",
+    env
+  );
+
+  auto fn = info[0].As<Napi::Function>();
+  callback = Napi::Persistent(fn);
+  tsfn = Napi::ThreadSafeFunction::New(
+    env,
+    callback.Value(),
+    "keyboard-layout-listener",
+    0,
+    1
+  );
+
+  env.SetInstanceData<KeyboardLayoutManager>(this);
+
+  env.AddCleanupHook([this]() {
+    this->Cleanup();
+  });
+
+  PlatformSetup(info);
 }
+
+// Runs on the main thread.
+void KeyboardLayoutManager::ProcessCallback(
+  Napi::Env env,
+  Napi::Function callback
+) {
+  auto that = env.GetInstanceData<KeyboardLayoutManager>();
+  auto current = that->GetCurrentKeyboardLayout(env);
+
+  callback.Call({current});
+}
+
+// Runs on a background thread.
+void KeyboardLayoutManager::OnNotificationReceived() {
+  // We don't need to send any arguments; we just need to signal the main
+  // thread.
+  tsfn.BlockingCall(KeyboardLayoutManager::ProcessCallback);
+}
+
+void KeyboardLayoutManager::Cleanup() {
+  callback.Reset();
+  if (isFinalizing) return;
+  tsfn.Abort();
+
+  PlatformTeardown();
+}
+
+KeyboardLayoutManager::~KeyboardLayoutManager() {
+  isFinalizing = true;
+  Cleanup();
+}
+
+void KeyboardLayoutManager::Init(Napi::Env env, Napi::Object exports) {
+#ifdef DEBUG
+  std::cout << "KeyboardLayoutManager::Init" << std::endl;
+#endif
+  Napi::Function func = DefineClass(env, "KeyboardLayoutManager", {
+    InstanceMethod<&KeyboardLayoutManager::GetCurrentKeyboardLayout>("getCurrentKeyboardLayout", napi_default_method),
+    InstanceMethod<&KeyboardLayoutManager::GetCurrentKeyboardLanguage>("getCurrentKeyboardLanguage", napi_default_method),
+    InstanceMethod<&KeyboardLayoutManager::GetInstalledKeyboardLanguages>("getInstalledKeyboardLanguages", napi_default_method),
+    InstanceMethod<&KeyboardLayoutManager::GetCurrentKeymap>("getCurrentKeymap", napi_default_method)
+  });
+
+  exports.Set("KeyboardLayoutManager", func);
+}
+
+Napi::Object Init(Napi::Env env, Napi::Object exports) {
+  KeyboardLayoutManager::Init(env, exports);
+  return exports;
+}
+
+NODE_API_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/src/keyboard-layout-manager.cc
+++ b/src/keyboard-layout-manager.cc
@@ -86,4 +86,4 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
   return exports;
 }
 
-NODE_API_MODULE(NODE_GYP_MODULE_NAME, Init)
+NODE_API_MODULE(keyboard_layout_manager, Init)

--- a/src/keyboard-layout-manager.cc
+++ b/src/keyboard-layout-manager.cc
@@ -1,6 +1,6 @@
 #include "keyboard-layout-manager.h"
-#ifdef DEBUG
 #include <iostream>
+#ifdef DEBUG
 #endif
 
 KeyboardLayoutManager::KeyboardLayoutManager(const Napi::CallbackInfo& info):
@@ -21,6 +21,7 @@ KeyboardLayoutManager::KeyboardLayoutManager(const Napi::CallbackInfo& info):
 
   auto fn = info[0].As<Napi::Function>();
   callback = Napi::Persistent(fn);
+  std::cout << "Declaring tsfn!" << std::endl;
   tsfn = Napi::ThreadSafeFunction::New(
     env,
     callback.Value(),
@@ -28,6 +29,11 @@ KeyboardLayoutManager::KeyboardLayoutManager(const Napi::CallbackInfo& info):
     0,
     1
   );
+
+  callback.Unref();
+  tsfn.Unref(env);
+
+  std::cout << "Unreffed the tsfn!" << std::endl;
 
   env.SetInstanceData<KeyboardLayoutManager>(this);
 
@@ -57,6 +63,7 @@ void KeyboardLayoutManager::OnNotificationReceived() {
 }
 
 void KeyboardLayoutManager::Cleanup() {
+  std::cout << "Cleanup!" << std::endl;
   callback.Reset();
   if (isFinalizing) return;
   tsfn.Abort();
@@ -65,6 +72,7 @@ void KeyboardLayoutManager::Cleanup() {
 }
 
 KeyboardLayoutManager::~KeyboardLayoutManager() {
+  std::cout << "Destructing!" << std::endl;
   isFinalizing = true;
   Cleanup();
 }

--- a/src/keyboard-layout-manager.cc
+++ b/src/keyboard-layout-manager.cc
@@ -77,7 +77,7 @@ void KeyboardLayoutManager::ProcessCallback(
 }
 
 // Static callback that doesn't rely on GetCurrentKeyboardLayout
-static void LayoutChangeCallback(Napi::Env env, Napi::Function jsCallback, void* /*data*/) {
+static void LayoutChangeCallback(Napi::Env env, Napi::Function jsCallback) {
   // Create a handle scope for this execution context
   Napi::HandleScope scope(env);
 

--- a/src/keyboard-layout-manager.cc
+++ b/src/keyboard-layout-manager.cc
@@ -11,6 +11,7 @@ KeyboardLayoutManager::KeyboardLayoutManager(const Napi::CallbackInfo& info):
   #endif
 
   auto env = info.Env();
+  _env = env;
   CHECK_VOID(
     info[0].IsFunction(),
     "Expected function as first argument",
@@ -72,7 +73,6 @@ void KeyboardLayoutManager::Init(Napi::Env env, Napi::Object exports) {
   std::cout << "KeyboardLayoutManager::Init" << std::endl;
 #endif
 
-  _env = env;
   Napi::Function func = DefineClass(env, "KeyboardLayoutManager", {
     InstanceMethod<&KeyboardLayoutManager::GetCurrentKeyboardLayout>("getCurrentKeyboardLayout", napi_default_method),
     InstanceMethod<&KeyboardLayoutManager::GetCurrentKeyboardLanguage>("getCurrentKeyboardLanguage", napi_default_method),

--- a/src/keyboard-layout-manager.cc
+++ b/src/keyboard-layout-manager.cc
@@ -44,51 +44,15 @@ KeyboardLayoutManager::KeyboardLayoutManager(const Napi::CallbackInfo& info):
 }
 
 // Runs on the main thread.
-#ifndef __linux__
 void KeyboardLayoutManager::ProcessCallback(
   Napi::Env env,
   Napi::Function callback
 ) {
-  auto that = env.GetInstanceData<KeyboardLayoutManager>();
-  Napi::Value result = that->GetCurrentKeyboardLayout(env);
+  // auto that = env.GetInstanceData<KeyboardLayoutManager>();
+  // Napi::Value result = that->GetCurrentKeyboardLayout(env);
 
-  callback.Call({ result });
-
-  // Napi::Value result;
-  // if (strcmp(rawResult, "") == 0) {
-  //   result = env.Null();
-  // } else {
-  //   result = Napi::String::New(env, rawResult);
-  // }
-  // that->GetCurrentKeyboardLayout(env);
-
-  // if (current.IsString()) {
-  //   Napi::String str = current.As<Napi::String>();
-  //   std::string value = str.Utf8Value();
-  //   std::cout << "Sanity check: value is " << value << std::endl;
-  // } else {
-  //   std::cout << "Sanity check: is NOT a string!";
-  // }
-
-  // callback.Call({ result });
-
-  // Create arguments array with the layout
-  // std::vector<napi_value> args = { str };
-  //
-  // // Call JS callback with explicit this and args
-  // napi_value global;
-  // napi_get_global(env, &global);
-  //
-  // napi_value result;
-  // napi_call_function(env, global, callback, 1, args.data(), &result);
-  //
-  // std::cout << "Weird Result: " << result << std::endl;
-
-  // Napi::Object global = env.Global();
-  // callback.MakeCallback(global, {current.As<Napi::String>()});
-  // callback.Call({current});
+  callback.Call({});
 }
-#endif
 
 // Runs on a background thread.
 void KeyboardLayoutManager::OnNotificationReceived() {

--- a/src/keyboard-layout-manager.cc
+++ b/src/keyboard-layout-manager.cc
@@ -54,13 +54,13 @@ void KeyboardLayoutManager::ProcessCallback(
 
   Napi::Object global = env.Global();
 
-  // Debug - check if current is valid
-  fprintf(stderr, "Current layout value is %s\n",
-          current.IsUndefined() ? "undefined" :
-          (current.IsNull() ? "null" : "defined"));
-
   // Create args array
   std::vector<napi_value> args = {current};
+
+  std::cout << "WAT? "
+            << (current.IsUndefined() ? "undefined"
+                                      : (current.IsNull() ? "null" : "defined"))
+            << std::endl;
 
   // Call with explicit this
   callback.Call(args);

--- a/src/keyboard-layout-manager.cc
+++ b/src/keyboard-layout-manager.cc
@@ -4,7 +4,8 @@
 #endif
 
 KeyboardLayoutManager::KeyboardLayoutManager(const Napi::CallbackInfo& info):
- Napi::ObjectWrap<KeyboardLayoutManager>(info) {
+ Napi::ObjectWrap<KeyboardLayoutManager>(info),
+ _env(info.Env()) {
   #if defined(__linux__) || defined(__FreeBSD__)
     xInputContext = nullptr;
     xInputMethod = nullptr;

--- a/src/keyboard-layout-manager.cc
+++ b/src/keyboard-layout-manager.cc
@@ -44,15 +44,26 @@ KeyboardLayoutManager::KeyboardLayoutManager(const Napi::CallbackInfo& info):
 }
 
 // Runs on the main thread.
+#ifdef __linux__
+    // Linux-specific version declaration
+void KeyboardLayoutManager::ProcessCallback(Napi::Env env, Napi::Function callback);
+#else
 void KeyboardLayoutManager::ProcessCallback(
   Napi::Env env,
   Napi::Function callback
 ) {
   auto that = env.GetInstanceData<KeyboardLayoutManager>();
-  that->GetCurrentKeyboardLayout(env);
+  Napi::Value result = that->GetCurrentKeyboardLayout(env);
 
-  const char* current = that->currentLayout;
-  Napi::String str = Napi::String::New(env, current);
+  callback.Call({ result });
+
+  // Napi::Value result;
+  // if (strcmp(rawResult, "") == 0) {
+  //   result = env.Null();
+  // } else {
+  //   result = Napi::String::New(env, rawResult);
+  // }
+  // that->GetCurrentKeyboardLayout(env);
 
   // if (current.IsString()) {
   //   Napi::String str = current.As<Napi::String>();
@@ -62,7 +73,7 @@ void KeyboardLayoutManager::ProcessCallback(
   //   std::cout << "Sanity check: is NOT a string!";
   // }
 
-  callback.Call({ str });
+  // callback.Call({ result });
 
   // Create arguments array with the layout
   // std::vector<napi_value> args = { str };
@@ -80,6 +91,7 @@ void KeyboardLayoutManager::ProcessCallback(
   // callback.MakeCallback(global, {current.As<Napi::String>()});
   // callback.Call({current});
 }
+#endif
 
 // Runs on a background thread.
 void KeyboardLayoutManager::OnNotificationReceived() {

--- a/src/keyboard-layout-manager.cc
+++ b/src/keyboard-layout-manager.cc
@@ -21,7 +21,6 @@ KeyboardLayoutManager::KeyboardLayoutManager(const Napi::CallbackInfo& info):
 
   auto fn = info[0].As<Napi::Function>();
   callback = Napi::Persistent(fn);
-  std::cout << "Declaring tsfn!" << std::endl;
   tsfn = Napi::ThreadSafeFunction::New(
     env,
     callback.Value(),
@@ -61,8 +60,8 @@ void KeyboardLayoutManager::ProcessCallback(
   }
 
   Napi::Object global = env.Global();
-
-  callback.Call({current});
+  callback.MakeCallback(global, {current});
+  // callback.Call({current});
 }
 
 // Runs on a background thread.

--- a/src/keyboard-layout-manager.cc
+++ b/src/keyboard-layout-manager.cc
@@ -76,6 +76,22 @@ void KeyboardLayoutManager::ProcessCallback(
   // callback.Call({current});
 }
 
+// Static callback that doesn't rely on GetCurrentKeyboardLayout
+static void LayoutChangeCallback(Napi::Env env, Napi::Function jsCallback, void* /*data*/) {
+  // Create a handle scope for this execution context
+  Napi::HandleScope scope(env);
+
+  // Create a hard-coded string value directly here
+  Napi::String layout = Napi::String::New(env, "test_direct_layout");
+
+  // Log before calling
+  fprintf(stderr, "About to call JS callback with direct layout: %s\n", "test_direct_layout");
+
+  // Call with explicit arguments
+  jsCallback.Call({layout});
+}
+
+
 // Runs on a background thread.
 void KeyboardLayoutManager::OnNotificationReceived() {
   // We don't need to send any arguments; we just need to signal the main
@@ -91,7 +107,7 @@ void KeyboardLayoutManager::OnNotificationReceived() {
   //         jsCallback.Call({arg});
   //       }
   //     });
-  tsfn.BlockingCall(KeyboardLayoutManager::ProcessCallback);
+  tsfn.BlockingCall(LayoutChangeCallback);
 }
 
 void KeyboardLayoutManager::Cleanup() {

--- a/src/keyboard-layout-manager.cc
+++ b/src/keyboard-layout-manager.cc
@@ -32,8 +32,6 @@ KeyboardLayoutManager::KeyboardLayoutManager(const Napi::CallbackInfo& info):
   callback.Unref();
   tsfn.Unref(env);
 
-  std::cout << "Unreffed the tsfn!" << std::endl;
-
   env.SetInstanceData<KeyboardLayoutManager>(this);
 
   env.AddCleanupHook([this]() {
@@ -48,9 +46,6 @@ void KeyboardLayoutManager::ProcessCallback(
   Napi::Env env,
   Napi::Function callback
 ) {
-  // auto that = env.GetInstanceData<KeyboardLayoutManager>();
-  // Napi::Value result = that->GetCurrentKeyboardLayout(env);
-
   callback.Call({});
 }
 
@@ -62,7 +57,6 @@ void KeyboardLayoutManager::OnNotificationReceived() {
 }
 
 void KeyboardLayoutManager::Cleanup() {
-  std::cout << "Cleanup!" << std::endl;
   callback.Reset();
   if (isFinalizing) return;
   tsfn.Abort();
@@ -71,7 +65,6 @@ void KeyboardLayoutManager::Cleanup() {
 }
 
 KeyboardLayoutManager::~KeyboardLayoutManager() {
-  std::cout << "Destructing!" << std::endl;
   isFinalizing = true;
   Cleanup();
 }

--- a/src/keyboard-layout-manager.cc
+++ b/src/keyboard-layout-manager.cc
@@ -109,39 +109,34 @@ static void LayoutChangeCallback(Napi::Env env, Napi::Function jsCallback) {
 }
 
 
-// Runs on a background thread.
 void KeyboardLayoutManager::OnNotificationReceived() {
-  // Create data - even though we're not using it, it helps with debugging
   const char* marker = "LAYOUT_CHANGE_EVENT";
 
-  // More explicit call
   napi_status status = tsfn.NonBlockingCall(
-    const_cast<char*>(marker),  // "data" to pass (just a marker)
+    const_cast<char*>(marker),
     [](Napi::Env env, Napi::Function jsCallback, char* data) {
-      // Extra debug info
-      fprintf(stderr, "ThreadSafeFunction callback executing. Data marker: %s\n", data);
+      fprintf(stderr, "ThreadSafeFunction callback executing.\n");
 
-      // Create a simple hard-coded value
-      Napi::String layout = Napi::String::New(env, "test_nonblocking_call");
+      // Try to get the instance data
+      auto that = env.GetInstanceData<KeyboardLayoutManager>();
+      if (that) {
+        fprintf(stderr, "Successfully retrieved instance data\n");
 
-      // Call with this value
-      jsCallback.Call({layout});
+        // Still use a hard-coded string for now
+        Napi::String layout = Napi::String::New(env, "test_with_instance_data");
+        jsCallback.Call({layout});
+      } else {
+        fprintf(stderr, "Failed to get instance data\n");
+
+        // Fall back to a different string so we can tell the difference
+        Napi::String layout = Napi::String::New(env, "no_instance_data");
+        jsCallback.Call({layout});
+      }
     }
   );
-  // We don't need to send any arguments; we just need to signal the main
-  // thread.
-  // tsfn.BlockingCall(
-  //     "layout_change",
-  //     [](Napi::Env env, Napi::Function jsCallback, const char *event_type) {
-  //       if (strcmp(event_type, "layout_change") == 0) {
-  //         // Create a string argument
-  //         Napi::String arg = Napi::String::New(env, "test_layout_value");
-  //
-  //         // Try calling with this test value first
-  //         jsCallback.Call({arg});
-  //       }
-  //     });
-  // tsfn.BlockingCall(LayoutChangeCallback);
+
+  fprintf(stderr, "ThreadSafeFunction call status: %s\n",
+          status == napi_ok ? "OK" : "ERROR");
 }
 
 void KeyboardLayoutManager::Cleanup() {

--- a/src/keyboard-layout-manager.cc
+++ b/src/keyboard-layout-manager.cc
@@ -29,11 +29,16 @@ KeyboardLayoutManager::KeyboardLayoutManager(const Napi::CallbackInfo& info):
 
   // Create the ThreadSafeFunction with more explicit parameters
   tsfn = Napi::ThreadSafeFunction::New(
-    env,                          // environment
-    callback.Value(),             // js_callback
-    "keyboard-layout-listener",   // resource_name
-    0,                            // max_queue_size
-    1                             // initial_thread_count
+    env,                        // environment
+    callback.Value(),           // js_callback
+    "keyboard-layout-listener", // resource_name
+    0,                          // max_queue_size
+    1,                          // initial_thread_count
+    this,
+    [](Napi::Env, void *) {     // finalize_cb
+                                // No-op finalize callback
+    },
+    this
   );
 
   // auto fn = info[0].As<Napi::Function>();
@@ -48,8 +53,6 @@ KeyboardLayoutManager::KeyboardLayoutManager(const Napi::CallbackInfo& info):
 
   callback.Unref();
   tsfn.Unref(env);
-
-  std::cout << "Unreffed the tsfn!" << std::endl;
 
   env.SetInstanceData<KeyboardLayoutManager>(this);
 
@@ -110,21 +113,22 @@ static void LayoutChangeCallback(Napi::Env env, Napi::Function jsCallback) {
 
 
 void KeyboardLayoutManager::OnNotificationReceived() {
-  const char* marker = "LAYOUT_CHANGE_EVENT";
 
   napi_status status = tsfn.NonBlockingCall(
-    const_cast<char*>(marker),
-    [](Napi::Env env, Napi::Function jsCallback, char* data) {
+    this,
+    [](Napi::Env env, Napi::Function jsCallback, KeyboardLayoutManager* that) {
       fprintf(stderr, "ThreadSafeFunction callback executing.\n");
 
       // Try to get the instance data
-      auto that = env.GetInstanceData<KeyboardLayoutManager>();
+      // auto that = env.GetInstanceData<KeyboardLayoutManager>();
       if (that) {
         fprintf(stderr, "Successfully retrieved instance data\n");
 
+        Napi::Value current = that->GetCurrentKeyboardLayout(env);
+
         // Still use a hard-coded string for now
-        Napi::String layout = Napi::String::New(env, "test_with_instance_data");
-        jsCallback.Call({layout});
+        // Napi::String layout = Napi::String::New(env, "test_with_instance_data");
+        jsCallback.Call({current});
       } else {
         fprintf(stderr, "Failed to get instance data\n");
 

--- a/src/keyboard-layout-manager.cc
+++ b/src/keyboard-layout-manager.cc
@@ -71,6 +71,8 @@ void KeyboardLayoutManager::Init(Napi::Env env, Napi::Object exports) {
 #ifdef DEBUG
   std::cout << "KeyboardLayoutManager::Init" << std::endl;
 #endif
+
+  _env = env;
   Napi::Function func = DefineClass(env, "KeyboardLayoutManager", {
     InstanceMethod<&KeyboardLayoutManager::GetCurrentKeyboardLayout>("getCurrentKeyboardLayout", napi_default_method),
     InstanceMethod<&KeyboardLayoutManager::GetCurrentKeyboardLanguage>("getCurrentKeyboardLanguage", napi_default_method),

--- a/src/keyboard-layout-manager.cc
+++ b/src/keyboard-layout-manager.cc
@@ -52,7 +52,13 @@ void KeyboardLayoutManager::ProcessCallback(
   auto that = env.GetInstanceData<KeyboardLayoutManager>();
   auto current = that->GetCurrentKeyboardLayout(env);
 
-  callback.Call({current});
+  Napi::Object global = env.Global();
+  // Create args array
+  std::vector<napi_value> args = {current};
+
+  // Call with explicit this
+  callback.Call(global, args);
+  // callback.Call({current});
 }
 
 // Runs on a background thread.

--- a/src/keyboard-layout-manager.cc
+++ b/src/keyboard-layout-manager.cc
@@ -19,40 +19,20 @@ KeyboardLayoutManager::KeyboardLayoutManager(const Napi::CallbackInfo& info):
     env
   );
 
-  // In constructor
   auto fn = info[0].As<Napi::Function>();
   callback = Napi::Persistent(fn);
-
-  // Log debug info
-  fprintf(stderr, "Creating ThreadSafeFunction. Callback is %s\n",
-          callback.IsEmpty() ? "empty" : "valid");
-
-  // Create the ThreadSafeFunction with more explicit parameters
   tsfn = Napi::ThreadSafeFunction::New(
-    env,                        // environment
-    callback.Value(),           // js_callback
-    "keyboard-layout-listener", // resource_name
-    0,                          // max_queue_size
-    1,                          // initial_thread_count
-    this,
-    [](Napi::Env, void* finalizeData) {     // finalize_cb
-                                // No-op finalize callback
-    }
-    // nullptr
+    env,
+    callback.Value(),
+    "keyboard-layout-listener",
+    0,
+    1
   );
-
-  // auto fn = info[0].As<Napi::Function>();
-  // callback = Napi::Persistent(fn);
-  // tsfn = Napi::ThreadSafeFunction::New(
-  //   env,
-  //   callback.Value(),
-  //   "keyboard-layout-listener",
-  //   0,
-  //   1
-  // );
 
   callback.Unref();
   tsfn.Unref(env);
+
+  std::cout << "Unreffed the tsfn!" << std::endl;
 
   env.SetInstanceData<KeyboardLayoutManager>(this);
 
@@ -69,77 +49,43 @@ void KeyboardLayoutManager::ProcessCallback(
   Napi::Function callback
 ) {
   auto that = env.GetInstanceData<KeyboardLayoutManager>();
-  auto current = that->GetCurrentKeyboardLayout(env);
+  that->GetCurrentKeyboardLayout(env);
 
-  if (current.IsString()) {
-    Napi::String str = current.As<Napi::String>();
-    std::string value = str.Utf8Value();
-    std::cout << "Sanity check: value is " << value << std::endl;
-  } else {
-    std::cout << "Sanity check: is NOT a string!";
-  }
+  const char* current = that->currentLayout;
+  Napi::String str = Napi::String::New(env, current);
+
+  // if (current.IsString()) {
+  //   Napi::String str = current.As<Napi::String>();
+  //   std::string value = str.Utf8Value();
+  //   std::cout << "Sanity check: value is " << value << std::endl;
+  // } else {
+  //   std::cout << "Sanity check: is NOT a string!";
+  // }
+
+  callback.Call({ str });
 
   // Create arguments array with the layout
-  std::vector<napi_value> args = { current };
-
-  // Call JS callback with explicit this and args
-  napi_value global;
-  napi_get_global(env, &global);
-
-  napi_value result;
-  napi_call_function(env, global, callback, 1, args.data(), &result);
-
-  std::cout << "Weird Result: " << result << std::endl;
+  // std::vector<napi_value> args = { str };
+  //
+  // // Call JS callback with explicit this and args
+  // napi_value global;
+  // napi_get_global(env, &global);
+  //
+  // napi_value result;
+  // napi_call_function(env, global, callback, 1, args.data(), &result);
+  //
+  // std::cout << "Weird Result: " << result << std::endl;
 
   // Napi::Object global = env.Global();
   // callback.MakeCallback(global, {current.As<Napi::String>()});
   // callback.Call({current});
 }
 
-// Static callback that doesn't rely on GetCurrentKeyboardLayout
-static void LayoutChangeCallback(Napi::Env env, Napi::Function jsCallback) {
-  // Create a handle scope for this execution context
-  Napi::HandleScope scope(env);
-
-  // Create a hard-coded string value directly here
-  Napi::String layout = Napi::String::New(env, "test_direct_layout");
-
-  // Log before calling
-  fprintf(stderr, "About to call JS callback with direct layout: %s\n", "test_direct_layout");
-
-  // Call with explicit arguments
-  jsCallback.Call({layout});
-}
-
-
+// Runs on a background thread.
 void KeyboardLayoutManager::OnNotificationReceived() {
-
-  napi_status status = tsfn.NonBlockingCall(
-    [this](Napi::Env env, Napi::Function jsCallback, KeyboardLayoutManager* that) {
-      fprintf(stderr, "ThreadSafeFunction callback executing.\n");
-
-      // Try to get the instance data
-      // auto that = env.GetInstanceData<KeyboardLayoutManager>();
-      if (that) {
-        fprintf(stderr, "Successfully retrieved instance data\n");
-
-        Napi::Value current = that->GetCurrentKeyboardLayout(env);
-
-        // Still use a hard-coded string for now
-        // Napi::String layout = Napi::String::New(env, "test_with_instance_data");
-        jsCallback.Call({current});
-      } else {
-        fprintf(stderr, "Failed to get instance data\n");
-
-        // Fall back to a different string so we can tell the difference
-        Napi::String layout = Napi::String::New(env, "no_instance_data");
-        jsCallback.Call({layout});
-      }
-    }
-  );
-
-  fprintf(stderr, "ThreadSafeFunction call status: %s\n",
-          status == napi_ok ? "OK" : "ERROR");
+  // We don't need to send any arguments; we just need to signal the main
+  // thread.
+  tsfn.BlockingCall(KeyboardLayoutManager::ProcessCallback);
 }
 
 void KeyboardLayoutManager::Cleanup() {

--- a/src/keyboard-layout-manager.cc
+++ b/src/keyboard-layout-manager.cc
@@ -19,15 +19,32 @@ KeyboardLayoutManager::KeyboardLayoutManager(const Napi::CallbackInfo& info):
     env
   );
 
+  // In constructor
   auto fn = info[0].As<Napi::Function>();
   callback = Napi::Persistent(fn);
+
+  // Log debug info
+  fprintf(stderr, "Creating ThreadSafeFunction. Callback is %s\n",
+          callback.IsEmpty() ? "empty" : "valid");
+
+  // Create the ThreadSafeFunction with more explicit parameters
   tsfn = Napi::ThreadSafeFunction::New(
-    env,
-    callback.Value(),
-    "keyboard-layout-listener",
-    0,
-    1
+    env,                          // environment
+    callback.Value(),             // js_callback
+    "keyboard-layout-listener",   // resource_name
+    0,                            // max_queue_size
+    1                             // initial_thread_count
   );
+
+  // auto fn = info[0].As<Napi::Function>();
+  // callback = Napi::Persistent(fn);
+  // tsfn = Napi::ThreadSafeFunction::New(
+  //   env,
+  //   callback.Value(),
+  //   "keyboard-layout-listener",
+  //   0,
+  //   1
+  // );
 
   callback.Unref();
   tsfn.Unref(env);
@@ -94,6 +111,23 @@ static void LayoutChangeCallback(Napi::Env env, Napi::Function jsCallback) {
 
 // Runs on a background thread.
 void KeyboardLayoutManager::OnNotificationReceived() {
+  // Create data - even though we're not using it, it helps with debugging
+  const char* marker = "LAYOUT_CHANGE_EVENT";
+
+  // More explicit call
+  napi_status status = tsfn.NonBlockingCall(
+    const_cast<char*>(marker),  // "data" to pass (just a marker)
+    [](Napi::Env env, Napi::Function jsCallback, char* data) {
+      // Extra debug info
+      fprintf(stderr, "ThreadSafeFunction callback executing. Data marker: %s\n", data);
+
+      // Create a simple hard-coded value
+      Napi::String layout = Napi::String::New(env, "test_nonblocking_call");
+
+      // Call with this value
+      jsCallback.Call({layout});
+    }
+  );
   // We don't need to send any arguments; we just need to signal the main
   // thread.
   // tsfn.BlockingCall(
@@ -107,7 +141,7 @@ void KeyboardLayoutManager::OnNotificationReceived() {
   //         jsCallback.Call({arg});
   //       }
   //     });
-  tsfn.BlockingCall(LayoutChangeCallback);
+  // tsfn.BlockingCall(LayoutChangeCallback);
 }
 
 void KeyboardLayoutManager::Cleanup() {

--- a/src/keyboard-layout-manager.cc
+++ b/src/keyboard-layout-manager.cc
@@ -60,7 +60,7 @@ void KeyboardLayoutManager::ProcessCallback(
   }
 
   Napi::Object global = env.Global();
-  callback.MakeCallback(global, {current});
+  callback.MakeCallback(global, {current.As<Napi::String>()});
   // callback.Call({current});
 }
 

--- a/src/keyboard-layout-manager.cc
+++ b/src/keyboard-layout-manager.cc
@@ -44,10 +44,7 @@ KeyboardLayoutManager::KeyboardLayoutManager(const Napi::CallbackInfo& info):
 }
 
 // Runs on the main thread.
-#ifdef __linux__
-    // Linux-specific version declaration
-void KeyboardLayoutManager::ProcessCallback(Napi::Env env, Napi::Function callback);
-#else
+#ifndef __linux__
 void KeyboardLayoutManager::ProcessCallback(
   Napi::Env env,
   Napi::Function callback

--- a/src/keyboard-layout-manager.cc
+++ b/src/keyboard-layout-manager.cc
@@ -80,18 +80,18 @@ void KeyboardLayoutManager::ProcessCallback(
 void KeyboardLayoutManager::OnNotificationReceived() {
   // We don't need to send any arguments; we just need to signal the main
   // thread.
-  tsfn.BlockingCall(
-      "layout_change",
-      [](Napi::Env env, Napi::Function jsCallback, const char *event_type) {
-        if (strcmp(event_type, "layout_change") == 0) {
-          // Create a string argument
-          Napi::String arg = Napi::String::New(env, "test_layout_value");
-
-          // Try calling with this test value first
-          jsCallback.Call({arg});
-        }
-      });
-  // tsfn.BlockingCall(KeyboardLayoutManager::ProcessCallback);
+  // tsfn.BlockingCall(
+  //     "layout_change",
+  //     [](Napi::Env env, Napi::Function jsCallback, const char *event_type) {
+  //       if (strcmp(event_type, "layout_change") == 0) {
+  //         // Create a string argument
+  //         Napi::String arg = Napi::String::New(env, "test_layout_value");
+  //
+  //         // Try calling with this test value first
+  //         jsCallback.Call({arg});
+  //       }
+  //     });
+  tsfn.BlockingCall(KeyboardLayoutManager::ProcessCallback);
 }
 
 void KeyboardLayoutManager::Cleanup() {

--- a/src/keyboard-layout-manager.cc
+++ b/src/keyboard-layout-manager.cc
@@ -35,7 +35,7 @@ KeyboardLayoutManager::KeyboardLayoutManager(const Napi::CallbackInfo& info):
     0,                          // max_queue_size
     1,                          // initial_thread_count
     this,
-    [](Napi::Env, void *) {     // finalize_cb
+    [](Napi::Env, void* finalizeData) {     // finalize_cb
                                 // No-op finalize callback
     },
     this

--- a/src/keyboard-layout-manager.cc
+++ b/src/keyboard-layout-manager.cc
@@ -59,8 +59,20 @@ void KeyboardLayoutManager::ProcessCallback(
     std::cout << "Sanity check: is NOT a string!";
   }
 
-  Napi::Object global = env.Global();
-  callback.MakeCallback(global, {current.As<Napi::String>()});
+  // Create arguments array with the layout
+  std::vector<napi_value> args = { current };
+
+  // Call JS callback with explicit this and args
+  napi_value global;
+  napi_get_global(env, &global);
+
+  napi_value result;
+  napi_call_function(env, global, callback, 1, args.data(), &result);
+
+  std::cout << "Weird Result: " << result << std::endl;
+
+  // Napi::Object global = env.Global();
+  // callback.MakeCallback(global, {current.As<Napi::String>()});
   // callback.Call({current});
 }
 

--- a/src/keyboard-layout-manager.cc
+++ b/src/keyboard-layout-manager.cc
@@ -52,19 +52,17 @@ void KeyboardLayoutManager::ProcessCallback(
   auto that = env.GetInstanceData<KeyboardLayoutManager>();
   auto current = that->GetCurrentKeyboardLayout(env);
 
+  if (current.IsString()) {
+    Napi::String str = current.As<Napi::String>();
+    std::string value = str.Utf8Value();
+    std::cout << "Sanity check: value is " << value << std::endl;
+  } else {
+    std::cout << "Sanity check: is NOT a string!";
+  }
+
   Napi::Object global = env.Global();
 
-  // Create args array
-  std::vector<napi_value> args = {current};
-
-  std::cout << "WAT? "
-            << (current.IsUndefined() ? "undefined"
-                                      : (current.IsNull() ? "null" : "defined"))
-            << std::endl;
-
-  // Call with explicit this
-  callback.Call(args);
-  // callback.Call({current});
+  callback.Call({current});
 }
 
 // Runs on a background thread.

--- a/src/keyboard-layout-manager.cc
+++ b/src/keyboard-layout-manager.cc
@@ -37,8 +37,8 @@ KeyboardLayoutManager::KeyboardLayoutManager(const Napi::CallbackInfo& info):
     this,
     [](Napi::Env, void* finalizeData) {     // finalize_cb
                                 // No-op finalize callback
-    },
-    this
+    }
+    // nullptr
   );
 
   // auto fn = info[0].As<Napi::Function>();
@@ -115,8 +115,7 @@ static void LayoutChangeCallback(Napi::Env env, Napi::Function jsCallback) {
 void KeyboardLayoutManager::OnNotificationReceived() {
 
   napi_status status = tsfn.NonBlockingCall(
-    this,
-    [](Napi::Env env, Napi::Function jsCallback, KeyboardLayoutManager* that) {
+    [this](Napi::Env env, Napi::Function jsCallback, KeyboardLayoutManager* that) {
       fprintf(stderr, "ThreadSafeFunction callback executing.\n");
 
       // Try to get the instance data

--- a/src/keyboard-layout-manager.cc
+++ b/src/keyboard-layout-manager.cc
@@ -80,7 +80,18 @@ void KeyboardLayoutManager::ProcessCallback(
 void KeyboardLayoutManager::OnNotificationReceived() {
   // We don't need to send any arguments; we just need to signal the main
   // thread.
-  tsfn.BlockingCall(KeyboardLayoutManager::ProcessCallback);
+  tsfn.BlockingCall(
+      "layout_change",
+      [](Napi::Env env, Napi::Function jsCallback, const char *event_type) {
+        if (strcmp(event_type, "layout_change") == 0) {
+          // Create a string argument
+          Napi::String arg = Napi::String::New(env, "test_layout_value");
+
+          // Try calling with this test value first
+          jsCallback.Call({arg});
+        }
+      });
+  // tsfn.BlockingCall(KeyboardLayoutManager::ProcessCallback);
 }
 
 void KeyboardLayoutManager::Cleanup() {

--- a/src/keyboard-layout-manager.cc
+++ b/src/keyboard-layout-manager.cc
@@ -53,11 +53,17 @@ void KeyboardLayoutManager::ProcessCallback(
   auto current = that->GetCurrentKeyboardLayout(env);
 
   Napi::Object global = env.Global();
+
+  // Debug - check if current is valid
+  fprintf(stderr, "Current layout value is %s\n",
+          current.IsUndefined() ? "undefined" :
+          (current.IsNull() ? "null" : "defined"));
+
   // Create args array
   std::vector<napi_value> args = {current};
 
   // Call with explicit this
-  callback.Call(global, args);
+  callback.Call(args);
   // callback.Call({current});
 }
 

--- a/src/keyboard-layout-manager.h
+++ b/src/keyboard-layout-manager.h
@@ -1,27 +1,56 @@
 #ifndef SRC_KEYBORD_LAYOUT_OBSERVER_H_
 #define SRC_KEYBORD_LAYOUT_OBSERVER_H_
 
-#include "nan.h"
+#include "napi.h"
+
+#define CHECK(cond, msg, env)                                  \
+if (!(cond)) {                                                 \
+  Napi::TypeError::New(env, msg).ThrowAsJavaScriptException(); \
+  return env.Null();                                           \
+}
+
+#define CHECK_VOID(cond, msg, env)                             \
+if (!(cond)) {                                                 \
+  Napi::TypeError::New(env, msg).ThrowAsJavaScriptException(); \
+  return;                                                      \
+}
+
+#define THROW(env, msg) {                                      \
+  Napi::TypeError::New(env, msg).ThrowAsJavaScriptException(); \
+}
+
+#define THROW_AND_RETURN(env, msg) {                           \
+  Napi::TypeError::New(env, msg).ThrowAsJavaScriptException(); \
+  return env.Null();                                           \
+}
+
 
 #if defined(__linux__) || defined(__FreeBSD__)
 #include <X11/Xlib.h>
 #endif // __linux__ || __FreeBSD__
 
-class KeyboardLayoutManager : public Nan::ObjectWrap {
- public:
-  void HandleKeyboardLayoutChanged();
-
-  static NAN_METHOD(New);
-  static NAN_METHOD(GetCurrentKeyboardLayout);
-  static NAN_METHOD(GetCurrentKeyboardLanguage);
-  static NAN_METHOD(GetInstalledKeyboardLanguages);
-  static NAN_METHOD(GetCurrentKeymap);
-
- private:
-  KeyboardLayoutManager(v8::Isolate* isolate, Nan::Callback *callback);
+class KeyboardLayoutManager : public Napi::ObjectWrap<KeyboardLayoutManager> {
+public:
+  static void Init(Napi::Env env, Napi::Object exports);
+  KeyboardLayoutManager(const Napi::CallbackInfo& info);
   ~KeyboardLayoutManager();
 
-  v8::Isolate* isolate() { return isolate_; }
+  void OnNotificationReceived();
+
+private:
+  Napi::Value GetCurrentKeyboardLayout(const Napi::CallbackInfo& info);
+  Napi::Value GetCurrentKeyboardLanguage(const Napi::CallbackInfo& info);
+  Napi::Value GetInstalledKeyboardLanguages(const Napi::CallbackInfo& info);
+  Napi::Value GetCurrentKeymap(const Napi::CallbackInfo& info);
+
+  Napi::Value GetCurrentKeyboardLayout(Napi::Env env);
+
+  void PlatformSetup(const Napi::CallbackInfo& info);
+  void PlatformTeardown();
+
+  void HandleKeyboardLayoutChanged();
+  static void ProcessCallback(Napi::Env env, Napi::Function callback);
+  void Cleanup();
 
 #if defined(__linux__) || defined(__FreeBSD__)
   Display *xDisplay;
@@ -29,8 +58,11 @@ class KeyboardLayoutManager : public Nan::ObjectWrap {
   XIM xInputMethod;
 #endif
 
-  v8::Isolate *isolate_;
-  Nan::Callback *callback;
+  bool isFinalizing = false;
+  Napi::FunctionReference callback;
+  Napi::ThreadSafeFunction tsfn;
 };
+
+Napi::Object Init(Napi::Env env, Napi::Object exports);
 
 #endif  // SRC_KEYBORD_LAYOUT_OBSERVER_H_

--- a/src/keyboard-layout-manager.h
+++ b/src/keyboard-layout-manager.h
@@ -30,6 +30,7 @@ if (!(cond)) {                                                 \
 #include <X11/Xlib.h>
 #include <wayland-client.h>
 #include <xkbcommon/xkbcommon.h>
+#include <string>
 
 typedef struct {
     struct wl_display *display;
@@ -62,7 +63,9 @@ public:
 #endif
 
 private:
-  const char* GetCurrentKeyboardLayout();
+#if defined(__linux__)
+  std::string GetCurrentKeyboardLayout();
+#endif
   Napi::Value GetCurrentKeyboardLayout(const Napi::CallbackInfo& info);
   Napi::Value GetCurrentKeyboardLanguage(const Napi::CallbackInfo& info);
   Napi::Value GetInstalledKeyboardLanguages(const Napi::CallbackInfo& info);

--- a/src/keyboard-layout-manager.h
+++ b/src/keyboard-layout-manager.h
@@ -35,18 +35,22 @@ if (!(cond)) {                                                 \
 #include <xkbcommon/xkbcommon.h>
 
 typedef struct {
-    struct wl_display *display;
-    struct wl_registry *registry;
-    struct wl_seat *seat;
-    struct wl_keyboard *keyboard;
-    struct xkb_context *xkb_context;
-    struct xkb_keymap *xkb_keymap;
-    struct xkb_state *xkb_state;
-    bool keymap_received;
-    xkb_mod_mask_t shift_mask;
-    xkb_mod_mask_t alt_gr_mask;
+  struct wl_display *display;
+  struct wl_registry *registry;
+  struct wl_seat *seat;
+  struct wl_keyboard *keyboard;
+  struct xkb_context *xkb_context;
+  struct xkb_keymap *xkb_keymap;
+  struct xkb_state *xkb_state;
+
+  // Whether we've received the first `keymap` event.
+  bool keymap_received;
+  // The modifier mask for the `Shift` key.
+  xkb_mod_mask_t shift_mask;
+  // The modifier mask for the `AltGr` key.
+  xkb_mod_mask_t alt_gr_mask;
 } WaylandKeymapContext;
-#endif
+#endif // HAS_WAYLAND
 
 #endif // __linux__ || __FreeBSD__
 
@@ -60,17 +64,16 @@ public:
 
   Napi::Env _env;
 #if defined(__linux__) || defined(__FreeBSD__)
+  void ProcessCallbackWrapper();
+
 #ifdef HAS_WAYLAND
   bool isWayland;
   WaylandKeymapContext *waylandContext;
-#endif
-  void ProcessCallbackWrapper();
-#endif
+#endif // HAS_WAYLAND
+
+#endif // __linux__ || __FreeBSD__
 
 private:
-#if defined(__linux__)
-  std::string GetCurrentKeyboardLayout();
-#endif
   Napi::Value GetCurrentKeyboardLayout(const Napi::CallbackInfo& info);
   Napi::Value GetCurrentKeyboardLanguage(const Napi::CallbackInfo& info);
   Napi::Value GetInstalledKeyboardLanguages(const Napi::CallbackInfo& info);
@@ -92,8 +95,8 @@ private:
   static void OnWaylandEvent(uv_poll_t* handle, int status, int events);
   void SetupWaylandPolling();
   void CleanupWaylandPolling();
-#endif
-#endif
+#endif // HAS_WAYLAND
+#endif // __linux__ || __FreeBSD__
 
   bool isFinalizing = false;
   Napi::FunctionReference callback;
@@ -102,4 +105,4 @@ private:
 
 Napi::Object Init(Napi::Env env, Napi::Object exports);
 
-#endif  // SRC_KEYBORD_LAYOUT_OBSERVER_H_
+#endif // SRC_KEYBORD_LAYOUT_OBSERVER_H_

--- a/src/keyboard-layout-manager.h
+++ b/src/keyboard-layout-manager.h
@@ -54,10 +54,11 @@ public:
 
   void OnNotificationReceived();
 
-#if defined(__linux__) || defined(__FreeBSD__)
+// #if defined(__linux__) || defined(__FreeBSD__)
+  Napi::Env env;
   bool isWayland;
   WaylandKeymapContext *waylandContext;
-#endif
+// #endif
 
 private:
   Napi::Value GetCurrentKeyboardLayout(const Napi::CallbackInfo& info);
@@ -75,9 +76,15 @@ private:
   void Cleanup();
 
 #if defined(__linux__) || defined(__FreeBSD__)
+  uv_poll_t* waylandPoll;
   Display *xDisplay;
   XIC xInputContext;
   XIM xInputMethod;
+
+  static void OnWaylandEvent(uv_poll_t* handle, int status, int events);
+  void SetupWaylandPolling();
+  void CleanupWaylandPolling();
+  void ProcessCallbackWrapper();
 #endif
 
   bool isFinalizing = false;

--- a/src/keyboard-layout-manager.h
+++ b/src/keyboard-layout-manager.h
@@ -56,7 +56,7 @@ public:
   void OnNotificationReceived();
 
 #if defined(__linux__) || defined(__FreeBSD__)
-  Napi::Env env;
+  Napi::Env _env;
   bool isWayland;
   WaylandKeymapContext *waylandContext;
 #endif

--- a/src/keyboard-layout-manager.h
+++ b/src/keyboard-layout-manager.h
@@ -54,6 +54,11 @@ public:
 
   void OnNotificationReceived();
 
+#if defined(__linux__) || defined(__FreeBSD__)
+  bool isWayland;
+  WaylandKeymapContext *waylandContext;
+#endif
+
 private:
   Napi::Value GetCurrentKeyboardLayout(const Napi::CallbackInfo& info);
   Napi::Value GetCurrentKeyboardLanguage(const Napi::CallbackInfo& info);
@@ -70,14 +75,9 @@ private:
   void Cleanup();
 
 #if defined(__linux__) || defined(__FreeBSD__)
-  bool isWayland;
-  WaylandKeymapContext* waylandContext;
   Display *xDisplay;
   XIC xInputContext;
   XIM xInputMethod;
-  xkb_context *xkbContext;
-  xkb_keymap *xkbKeymap;
-  xkb_state *xkbState;
 #endif
 
   bool isFinalizing = false;

--- a/src/keyboard-layout-manager.h
+++ b/src/keyboard-layout-manager.h
@@ -28,11 +28,11 @@ if (!(cond)) {                                                 \
 
 #if defined(__linux__) || defined(__FreeBSD__)
 #include <X11/Xlib.h>
+#include <string>
+
 #ifdef HAS_WAYLAND
 #include <wayland-client.h>
 #include <xkbcommon/xkbcommon.h>
-#endif
-#include <string>
 
 typedef struct {
     struct wl_display *display;
@@ -46,6 +46,7 @@ typedef struct {
     xkb_mod_mask_t shift_mask;
     xkb_mod_mask_t alt_gr_mask;
 } WaylandKeymapContext;
+#endif
 
 #endif // __linux__ || __FreeBSD__
 
@@ -59,8 +60,10 @@ public:
 
   Napi::Env _env;
 #if defined(__linux__) || defined(__FreeBSD__)
+#ifdef HAS_WAYLAND
   bool isWayland;
   WaylandKeymapContext *waylandContext;
+#endif
   void ProcessCallbackWrapper();
 #endif
 
@@ -80,14 +83,16 @@ private:
   void Cleanup();
 
 #if defined(__linux__) || defined(__FreeBSD__)
-  uv_poll_t* waylandPoll;
   Display *xDisplay;
   XIC xInputContext;
   XIM xInputMethod;
 
+#ifdef HAS_WAYLAND
+  uv_poll_t* waylandPoll;
   static void OnWaylandEvent(uv_poll_t* handle, int status, int events);
   void SetupWaylandPolling();
   void CleanupWaylandPolling();
+#endif
 #endif
 
   bool isFinalizing = false;

--- a/src/keyboard-layout-manager.h
+++ b/src/keyboard-layout-manager.h
@@ -31,7 +31,6 @@ if (!(cond)) {                                                 \
 #include <wayland-client.h>
 #include <xkbcommon/xkbcommon.h>
 
-// Add this struct definition outside your class
 typedef struct {
     struct wl_display *display;
     struct wl_registry *registry;

--- a/src/keyboard-layout-manager.h
+++ b/src/keyboard-layout-manager.h
@@ -59,10 +59,10 @@ public:
   bool isWayland;
   WaylandKeymapContext *waylandContext;
   void ProcessCallbackWrapper();
-  const char* currentLayout;
 #endif
 
 private:
+  const char* GetCurrentKeyboardLayout();
   Napi::Value GetCurrentKeyboardLayout(const Napi::CallbackInfo& info);
   Napi::Value GetCurrentKeyboardLanguage(const Napi::CallbackInfo& info);
   Napi::Value GetInstalledKeyboardLanguages(const Napi::CallbackInfo& info);

--- a/src/keyboard-layout-manager.h
+++ b/src/keyboard-layout-manager.h
@@ -58,8 +58,6 @@ private:
   Display *xDisplay;
   XIC xInputContext;
   XIM xInputMethod;
-  KeyboardMonitor* monitor;
-  const struct wl_keyboard_listener keyboard_listener;
 #endif
 
   bool isFinalizing = false;

--- a/src/keyboard-layout-manager.h
+++ b/src/keyboard-layout-manager.h
@@ -28,6 +28,8 @@ if (!(cond)) {                                                 \
 #if defined(__linux__) || defined(__FreeBSD__)
 #include <X11/Xlib.h>
 #include <wayland-client.h>
+#include <wayland-client-protocol.h>
+#include <xkbcommon/xkbcommon.h>
 #endif // __linux__ || __FreeBSD__
 
 class KeyboardLayoutManager : public Napi::ObjectWrap<KeyboardLayoutManager> {
@@ -58,6 +60,9 @@ private:
   Display *xDisplay;
   XIC xInputContext;
   XIM xInputMethod;
+  xkb_context *xkbContext;
+  xkb_keymap *xkbKeymap;
+  xkb_state *xkbState;
 #endif
 
   bool isFinalizing = false;

--- a/src/keyboard-layout-manager.h
+++ b/src/keyboard-layout-manager.h
@@ -27,6 +27,7 @@ if (!(cond)) {                                                 \
 
 #if defined(__linux__) || defined(__FreeBSD__)
 #include <X11/Xlib.h>
+#include <wayland-client.h>
 #endif // __linux__ || __FreeBSD__
 
 class KeyboardLayoutManager : public Napi::ObjectWrap<KeyboardLayoutManager> {
@@ -53,9 +54,12 @@ private:
   void Cleanup();
 
 #if defined(__linux__) || defined(__FreeBSD__)
+  bool isWayland;
   Display *xDisplay;
   XIC xInputContext;
   XIM xInputMethod;
+  KeyboardMonitor* monitor;
+  const struct wl_keyboard_listener keyboard_listener;
 #endif
 
   bool isFinalizing = false;

--- a/src/keyboard-layout-manager.h
+++ b/src/keyboard-layout-manager.h
@@ -54,11 +54,11 @@ public:
 
   void OnNotificationReceived();
 
-// #if defined(__linux__) || defined(__FreeBSD__)
+#if defined(__linux__) || defined(__FreeBSD__)
   Napi::Env env;
   bool isWayland;
   WaylandKeymapContext *waylandContext;
-// #endif
+#endif
 
 private:
   Napi::Value GetCurrentKeyboardLayout(const Napi::CallbackInfo& info);

--- a/src/keyboard-layout-manager.h
+++ b/src/keyboard-layout-manager.h
@@ -59,6 +59,7 @@ public:
   bool isWayland;
   WaylandKeymapContext *waylandContext;
   void ProcessCallbackWrapper();
+  const char* currentLayout;
 #endif
 
 private:

--- a/src/keyboard-layout-manager.h
+++ b/src/keyboard-layout-manager.h
@@ -55,8 +55,8 @@ public:
 
   void OnNotificationReceived();
 
-#if defined(__linux__) || defined(__FreeBSD__)
   Napi::Env _env;
+#if defined(__linux__) || defined(__FreeBSD__)
   bool isWayland;
   WaylandKeymapContext *waylandContext;
 #endif

--- a/src/keyboard-layout-manager.h
+++ b/src/keyboard-layout-manager.h
@@ -28,8 +28,22 @@ if (!(cond)) {                                                 \
 #if defined(__linux__) || defined(__FreeBSD__)
 #include <X11/Xlib.h>
 #include <wayland-client.h>
-#include <wayland-client-protocol.h>
 #include <xkbcommon/xkbcommon.h>
+
+// Add this struct definition outside your class
+typedef struct {
+    struct wl_display *display;
+    struct wl_registry *registry;
+    struct wl_seat *seat;
+    struct wl_keyboard *keyboard;
+    struct xkb_context *xkb_context;
+    struct xkb_keymap *xkb_keymap;
+    struct xkb_state *xkb_state;
+    bool keymap_received;
+    xkb_mod_mask_t shift_mask;
+    xkb_mod_mask_t alt_gr_mask;
+} WaylandKeymapContext;
+
 #endif // __linux__ || __FreeBSD__
 
 class KeyboardLayoutManager : public Napi::ObjectWrap<KeyboardLayoutManager> {
@@ -57,6 +71,7 @@ private:
 
 #if defined(__linux__) || defined(__FreeBSD__)
   bool isWayland;
+  WaylandKeymapContext* waylandContext;
   Display *xDisplay;
   XIC xInputContext;
   XIM xInputMethod;

--- a/src/keyboard-layout-manager.h
+++ b/src/keyboard-layout-manager.h
@@ -2,6 +2,7 @@
 #define SRC_KEYBORD_LAYOUT_OBSERVER_H_
 
 #include "napi.h"
+#include <uv.h>
 
 #define CHECK(cond, msg, env)                                  \
 if (!(cond)) {                                                 \

--- a/src/keyboard-layout-manager.h
+++ b/src/keyboard-layout-manager.h
@@ -59,6 +59,7 @@ public:
 #if defined(__linux__) || defined(__FreeBSD__)
   bool isWayland;
   WaylandKeymapContext *waylandContext;
+  void ProcessCallbackWrapper();
 #endif
 
 private:
@@ -85,7 +86,6 @@ private:
   static void OnWaylandEvent(uv_poll_t* handle, int status, int events);
   void SetupWaylandPolling();
   void CleanupWaylandPolling();
-  void ProcessCallbackWrapper();
 #endif
 
   bool isFinalizing = false;

--- a/src/keyboard-layout-manager.h
+++ b/src/keyboard-layout-manager.h
@@ -28,8 +28,10 @@ if (!(cond)) {                                                 \
 
 #if defined(__linux__) || defined(__FreeBSD__)
 #include <X11/Xlib.h>
+#ifdef HAS_WAYLAND
 #include <wayland-client.h>
 #include <xkbcommon/xkbcommon.h>
+#endif
 #include <string>
 
 typedef struct {

--- a/src/keyboard-layout-manager.h
+++ b/src/keyboard-layout-manager.h
@@ -71,12 +71,9 @@ private:
   Napi::Value GetInstalledKeyboardLanguages(const Napi::CallbackInfo& info);
   Napi::Value GetCurrentKeymap(const Napi::CallbackInfo& info);
 
-  Napi::Value GetCurrentKeyboardLayout(Napi::Env env);
-
   void PlatformSetup(const Napi::CallbackInfo& info);
   void PlatformTeardown();
 
-  void HandleKeyboardLayoutChanged();
   static void ProcessCallback(Napi::Env env, Napi::Function callback);
   void Cleanup();
 

--- a/test.js
+++ b/test.js
@@ -1,27 +1,8 @@
 const KeyboardLayout = require('./lib/keyboard-layout');
 console.log('LOADED!');
 
-// Force immediate exit
-// process.exit(0);
-// console.log('Current layout:', KeyboardLayout.getCurrentKeyboardLayout());
-//
-// console.log('Process should exit now...');
-// // Give it a moment to try to exit naturally
-// setTimeout(() => {
-//   console.log('Process is still running after 1 second');
-//   // Use internal Node.js API to check what might be keeping it alive
-//   try {
-//     const handles = process._getActiveHandles();
-//     console.log(`${handles.length} active handles`);
-//     handles.forEach((h, i) => console.log(`Handle ${i} type:`, h.constructor.name));
-//
-//     const requests = process._getActiveRequests();
-//     console.log(`${requests.length} active requests`);
-//
-//     // Try forcing exit
-//     process.exit(0);
-//   } catch (e) {
-//     console.error('Error in diagnostics:', e);
-//     process.exit(1);
-//   }
-// }, 1000);
+console.log('Current layout:', KeyboardLayout.getCurrentKeyboardLayout());
+
+setTimeout(() => {
+  console.log('aha!');
+}, 5000)

--- a/test.js
+++ b/test.js
@@ -1,0 +1,13 @@
+const KeyboardLayout = require('./lib/keyboard-layout')
+
+
+let listener = KeyboardLayout.onDidChangeCurrentKeyboardLayout((current) => {
+  console.log('AHA!', current);
+});
+
+console.log('Current layout:', KeyboardLayout.getCurrentKeyboardLayout());
+
+setTimeout(() => {
+  console.log('Done!');
+  listener.dispose();
+}, 30000);

--- a/test.js
+++ b/test.js
@@ -1,8 +1,11 @@
 const KeyboardLayout = require('./lib/keyboard-layout');
-console.log('LOADED!');
 
 console.log('Current layout:', KeyboardLayout.getCurrentKeyboardLayout());
 
+KeyboardLayout.onDidChangeCurrentKeyboardLayout((current) => {
+  console.log('CHANGED!!!!', current);
+});
+
 setTimeout(() => {
   console.log('aha!');
-}, 5000)
+}, 25000)

--- a/test.js
+++ b/test.js
@@ -5,9 +5,9 @@ let listener = KeyboardLayout.onDidChangeCurrentKeyboardLayout((current) => {
   console.log('AHA!', current);
 });
 
-console.log('Current layout:', KeyboardLayout.getCurrentKeyboardLayout());
-
 setTimeout(() => {
   console.log('Done!');
   listener.dispose();
-}, 30000);
+}, 5000);
+
+console.log('Current layout:', KeyboardLayout.getCurrentKeyboardLayout());

--- a/test.js
+++ b/test.js
@@ -1,13 +1,27 @@
-const KeyboardLayout = require('./lib/keyboard-layout')
+const KeyboardLayout = require('./lib/keyboard-layout');
+console.log('LOADED!');
 
-
-let listener = KeyboardLayout.onDidChangeCurrentKeyboardLayout((current) => {
-  console.log('AHA!', current);
-});
-
-setTimeout(() => {
-  console.log('Done!');
-  listener.dispose();
-}, 5000);
-
-console.log('Current layout:', KeyboardLayout.getCurrentKeyboardLayout());
+// Force immediate exit
+// process.exit(0);
+// console.log('Current layout:', KeyboardLayout.getCurrentKeyboardLayout());
+//
+// console.log('Process should exit now...');
+// // Give it a moment to try to exit naturally
+// setTimeout(() => {
+//   console.log('Process is still running after 1 second');
+//   // Use internal Node.js API to check what might be keeping it alive
+//   try {
+//     const handles = process._getActiveHandles();
+//     console.log(`${handles.length} active handles`);
+//     handles.forEach((h, i) => console.log(`Handle ${i} type:`, h.constructor.name));
+//
+//     const requests = process._getActiveRequests();
+//     console.log(`${requests.length} active requests`);
+//
+//     // Try forcing exit
+//     process.exit(0);
+//   } catch (e) {
+//     console.error('Error in diagnostics:', e);
+//     process.exit(1);
+//   }
+// }, 1000);


### PR DESCRIPTION
This brings `master` up to the version of `keyboard-layout` that has been used in PulsarNext since May. It delivers two major additions.

## N-API rewrite

The rewrite in N-API was part of demonstrating context-awareness; could’ve opted into context-awareness while continuing to use `nan`, but we might as well go whole hog.

## Wayland support

The much larger change snuck up on me: back in May, a French user downloaded PulsarNext in order to get Wayland support and was pleased with it… except that it assumed their keyboard was standard US QWERTY and was misinterpreting keystrokes. I discovered that this package’s keyboard detection was exclusively using X11 APIs, so when the user was on Wayland, we had no insight into their keyboard layout and fell back to a QWERTY assumption.

The next few days of code authorship were not my favorite, but eventually this got addressed. We now start out assuming the user is on Wayland, but will very quickly fall back to X11 if that assumption is violated in any way. (This also at least gives the X11 code path a chance to provide answers, since it may still be able to help us if the user is running the XWayland compatibility layer.)

I was able to do some basic sanity-checking in a Linux VM running Wayland. (Issue #3 chronicles my efforts.) I updated PulsarNext to point to this branch and the French user reported that the new version fixed their keyboard shortcuts.

So that’s where we are now. One of the big upsides of PulsarNext over mainline Pulsar for Linux users is that we inherit the Wayland support that was added to Electron itself at some point, but that support will be pretty shallow for non-US users if we can’t also detect their keystrokes properly.

## Testing

Testing these changes is not easy. The existing spec suite did only basic checking of Linux. And keyboard input in particular is hard to test in a CI environment. (If anyone has bright ideas, let me know. My initial experiments were not fruitful.)

I’m hoping that @mauricioszabo has the ability to do some sanity checking in Linux. If not, we might just need to rely on the fact that this fixed layout handling [for at least one Wayland user](https://github.com/pulsar-edit/pulsar/issues/381#issuecomment-2872677496) and land it for now.

## Next steps

As with `pathwatcher`, we have never relied on our own fork of `keyboard-layout`, and mainline Pulsar still points to `keyboard-layout` from NPM. So we don't need to publish `@pulsar-edit/keyboard-layout` until after we land this change. But the publish workflow already exists in this repo and I'll make sure it has access to the necessary secret.