### PR TITLE
Stop considering `XInputContext` in X11…

### DIFF
--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -14,6 +14,10 @@
 #include <iostream>
 #endif
 
+// Whether to check XInputContext when trying to match up a keyboard key with
+// a character.
+#define USE_XIC 0
+
 // Wayland-only block begins…
 #ifdef HAS_WAYLAND
 
@@ -560,7 +564,10 @@ Napi::Value CharacterForNativeCode(Napi::Env env, XIC xInputContext,
   keyEvent->keycode = xkbKeycode;
   keyEvent->state = state;
 
-  if (xInputContext) {
+  // We're keeping this code path around so that we can return to using it in
+  // certain scenarios if need be. But for now it's producing the wrong results
+  // in many cases.
+  if (USE_XIC) {
     wchar_t characters[2];
     char utf8[MB_CUR_MAX * 2 + 1];
     int count =


### PR DESCRIPTION
…when translating keys to characters.

Here's how this library is supposed to work:

```js
require('@pulsar-edit/keyboard-layout').getCurrentKeyMap();
// {
//   KeyA: { unmodified: 'q', withShift: 'Q' },
//   KeyB: { unmodified: 'b', withShift: 'B' },
//   KeyC: { unmodified: 'c', withShift: 'C' },
//   KeyD: { unmodified: 'd', withShift: 'D' },
//   ...
// }
```

The properties like `KeyA` represent the traditional positions of keys on a US QWERTY-style keyboard. In the US, `KeyA` produces `a` when presssed. In France, they use AZERTY, and you've got to press the key called `KeyQ` to produce an A and vice-versa (as the example results above illustrate).

This has worked just fine for a while. Now, however, in X11 environments, the above call produces:

```js
// {
//   KeyA: { unmodified: 'q', withShift: 'Q' }
// }
```

That's not truncated — that's the whole thing.

This was murder to debug because the very act of inserting logging statements in the critical code paths _changed the results_. Can't tell if it was a timing issue or related to some other side effects. Claude's theory is that `XwcLookupString` is being somewhat misused here, and was misinterpreting a tight loop (where we match up each key in the keyboard layout with its character equivalent) as some sort of composition sequence.

Originally, Atom used `XLookupString` on Linux exclusively. [#24](https://github.com/atom/keyboard-layout/pull/24) moved entirely to `XwcLookupString`  on the theory that it was better in non-Roman alphabets. (I agree in theory, but only if it actually works.) But since it doesn't work correctly when no windows are open, [#26](https://github.com/atom/keyboard-layout/pull/26) re-introduced `XLookupString` as a fallback path when an `XInputContext` could not be acquired.

So why did this suddenly stop working right now that we've upgraded Node and Electron? I have no clue. In fact, I can't yet be certain that the effects will be the same in an Electron environment as they were in an interactive Node session. But here's what it looks like for me currently in Linux/GNOME/X11:

<img width="437" height="82" alt="Screenshot 2026-02-26 at 9 20 22 PM" src="https://github.com/user-attachments/assets/c1ac9270-0ad0-4206-bc20-fd65f253a8ce" />

I'm optimistic that this will have a similar effect in Electron, even if the root causes are somehow different.